### PR TITLE
Allow User to End Lifespan of Building in Production

### DIFF
--- a/buildings/gui/alter_building_relationships.py
+++ b/buildings/gui/alter_building_relationships.py
@@ -838,7 +838,7 @@ class AlterRelationships(QFrame, FORM_CLASS):
             bulk_load_id = self.db.execute_no_commit(sql, (self.current_dataset, None, 2, capture_method, capture_source, suburb, town_city, territorial_auth, geometry))
             bulk_load_id = bulk_load_id.fetchall()[0][0]
             # remove existing building from removed table
-            sql = 'SELECT buildings_bulk_load.removed_delete_existing_outlines(%s);'
+            sql = 'SELECT buildings_bulk_load.removed_delete_existing_outline(%s);'
             self.db.execute_no_commit(sql, (building_outline_id,))
             # add existing and new building to matched table
             sql = 'SELECT buildings_bulk_load.matched_insert_building_outlines(%s, %s);'
@@ -1039,7 +1039,7 @@ class AlterRelationships(QFrame, FORM_CLASS):
     def delete_original_relationships(self):
         sql_delete_related_existing = 'SELECT buildings_bulk_load.related_delete_existing_outlines(%s);'
         sql_delete_matched_existing = 'SELECT buildings_bulk_load.matched_delete_existing_outlines(%s);'
-        sql_delete_removed = 'SELECT buildings_bulk_load.removed_delete_existing_outlines(%s);'
+        sql_delete_removed = 'SELECT buildings_bulk_load.removed_delete_existing_outline(%s);'
         sql_delete_added = 'SELECT buildings_bulk_load.added_delete_bulk_load_outlines(%s);'
 
         for row in range(self.lst_existing.count()):

--- a/buildings/gui/production_changes.py
+++ b/buildings/gui/production_changes.py
@@ -474,6 +474,7 @@ class EditAttribute(ProductionChanges):
                 for a in sel.actions()[0:3]:
                     iface.building_toolbar.addAction(a)
         iface.building_toolbar.show()
+        self.msgbox_remove = self.confirmation_dialog_box('remove')
 
         self.disable_UI_functions()
 
@@ -548,7 +549,6 @@ class EditAttribute(ProductionChanges):
     @pyqtSlot()
     def end_lifespan(self, commit_status):
         # get the dataset id and dates of the most recent supplied dataset
-        self.msgbox_remove = self.confirmation_dialog_box('remove')
         if not self.confirm(self.msgbox_remove):
             return
         dates = self.production_frame.db._execute(bulk_load_select.supplied_dataset_latest_id_and_dates)

--- a/buildings/gui/production_edits.ui
+++ b/buildings/gui/production_edits.ui
@@ -195,20 +195,20 @@ QGroupBox::title {
       <item>
        <widget class="QWidget" name="layout_general_info" native="true">
         <layout class="QGridLayout" name="gridLayout_4">
-         <item row="2" column="1">
+         <item row="6" column="1">
+          <widget class="QComboBox" name="cmb_town"/>
+         </item>
+         <item row="4" column="1">
           <widget class="QComboBox" name="cmb_ta"/>
          </item>
-         <item row="1" column="1">
-          <widget class="QComboBox" name="cmb_lifecycle_stage"/>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="lb_ta">
+         <item row="6" column="0">
+          <widget class="QLabel" name="lb_town">
            <property name="text">
-            <string>Territorial Authority: </string>
+            <string>Town City:</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="lb_lifeycle_stage">
            <property name="font">
             <font>
@@ -222,35 +222,35 @@ QGroupBox::title {
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="cmb_capture_source"/>
+         <item row="5" column="0">
+          <widget class="QLabel" name="lb_suburb">
+           <property name="text">
+            <string>Suburb Locality:</string>
+           </property>
+          </widget>
          </item>
          <item row="3" column="1">
+          <widget class="QComboBox" name="cmb_lifecycle_stage"/>
+         </item>
+         <item row="5" column="1">
           <widget class="QComboBox" name="cmb_suburb"/>
          </item>
-         <item row="0" column="0">
+         <item row="4" column="0">
+          <widget class="QLabel" name="lb_ta">
+           <property name="text">
+            <string>Territorial Authority: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
           <widget class="QLabel" name="lb_capture_source">
            <property name="text">
             <string>Capture Source:</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="lb_town">
-           <property name="text">
-            <string>Town City:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QComboBox" name="cmb_town"/>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="lb_suburb">
-           <property name="text">
-            <string>Suburb Locality:</string>
-           </property>
-          </widget>
+         <item row="2" column="1">
+          <widget class="QComboBox" name="cmb_capture_source"/>
          </item>
         </layout>
        </widget>
@@ -318,6 +318,51 @@ QGroupBox::title {
            </property>
            <property name="text">
             <string>Exit Editing</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="layout_end_lifespan" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="lb_or">
+           <property name="text">
+            <string>OR:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btn_end_lifespan">
+           <property name="minimumSize">
+            <size>
+             <width>250</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>End Lifespan</string>
            </property>
           </widget>
          </item>

--- a/buildings/gui/production_frame.py
+++ b/buildings/gui/production_frame.py
@@ -58,6 +58,7 @@ class ProductionFrame(QFrame, FORM_CLASS):
         self.tbtn_edits.setMenu(self.menu)
         self.layout_capture_method.hide()
         self.layout_general_info.hide()
+        self.layout_end_lifespan.hide()
         __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
         self.btn_circle.setIcon(QIcon(os.path.join(__location__, '..', 'icons', 'circle.png')))
 
@@ -163,6 +164,7 @@ class ProductionFrame(QFrame, FORM_CLASS):
             pass
         self.layout_capture_method.show()
         self.layout_general_info.show()
+        self.layout_end_lifespan.show()
         self.change_instance = production_changes.AddProduction(self)
         # set up circle button
         self.btn_circle.clicked.connect(self.change_instance.setup_circle)
@@ -206,13 +208,19 @@ class ProductionFrame(QFrame, FORM_CLASS):
             self.btn_exit_edits.clicked.disconnect()
         except Exception:
             pass
+        try:
+            self.btn_end_lifespan.clicked.disconnect()
+        except Exception:
+            pass
         self.layout_capture_method.show()
         self.layout_general_info.show()
+        self.layout_end_lifespan.show()
         self.change_instance = production_changes.EditAttribute(self)
         # set up signals and slots
         self.btn_save.clicked.connect(partial(self.change_instance.save_clicked, True))
         self.btn_reset.clicked.connect(self.change_instance.reset_clicked)
         self.btn_exit_edits.clicked.connect(self.exit_editing_clicked)
+        self.btn_end_lifespan.clicked.connect(partial(self.change_instance.end_lifespan, True))
         self.building_layer.selectionChanged.connect(self.change_instance.selection_changed)
         # add territorial authority layer
         self.territorial_auth = self.layer_registry.add_postgres_layer(
@@ -245,6 +253,7 @@ class ProductionFrame(QFrame, FORM_CLASS):
             pass
         self.layout_capture_method.show()
         self.layout_general_info.hide()
+        self.layout_end_lifespan.hide()
         self.change_instance = production_changes.EditGeometry(self)
         # set up signals and slots
         self.btn_save.clicked.connect(partial(self.change_instance.save_clicked, True))
@@ -333,6 +342,7 @@ class ProductionFrame(QFrame, FORM_CLASS):
         # hide comboboxes
         self.layout_capture_method.hide()
         self.layout_general_info.hide()
+        self.layout_end_lifespan.hide()
         iface.actionCancelEdits().trigger()
         # reload layers
         QgsMapLayerRegistry.instance().layerWillBeRemoved.disconnect(self.layers_removed)

--- a/buildings/sql/buildings_bulk_load_select_statements.py
+++ b/buildings/sql/buildings_bulk_load_select_statements.py
@@ -24,6 +24,7 @@ Bulk Load Outlines Select Statements:
 
 - existing_subset_extracts
   - existing_subset_extracts_by_building_outline_id (building_outline_id)
+  - existing_subset_extracts_dataset_by_building_outline_id
 
 - matched
   - matched_by_bulk_load_outline_id_dataset_id (bulk_load_outline_id, supplied_dataset_id)
@@ -46,12 +47,14 @@ Bulk Load Outlines Select Statements:
 - removed
   - removed_by_dataset_id (supplied_dataset_id)
   - removed_by_existing_outline_id_dataset_id (building_outline_id, supplied_dataset_id)
+  - removed_count_by_building_outline_id (building_outline_id)
 
 - supplied_dataset
   - supplied_dataset_count_both_dates_are_null
   - supplied_dataset_count_processed_date_is_null
   - supplied_dataset_count_transfer_date_is_null
   - supplied_dataset_description_by_dataset_id (supplied_dataset_id)
+  - supplied_dataset_latest_id_and_dates
   - supplied_dataset_processed_date_by_dataset_id (supplied_dataset_id)
   - supplied_dataset_processed_date_is_null
   - supplied_dataset_transfer_date_is_null
@@ -148,6 +151,12 @@ ORDER BY description;
 
 existing_subset_extracts_by_building_outline_id = """
 SELECT building_outline_id
+FROM buildings_bulk_load.existing_subset_extracts
+WHERE building_outline_id = %s;
+"""
+
+existing_subset_extracts_dataset_by_building_outline_id = """
+SELECT supplied_dataset_id
 FROM buildings_bulk_load.existing_subset_extracts
 WHERE building_outline_id = %s;
 """
@@ -273,6 +282,12 @@ JOIN buildings_bulk_load.existing_subset_extracts USING (building_outline_id)
 WHERE building_outline_id = %s AND supplied_dataset_id = %s;
 """
 
+removed_count_by_building_outline_id = """
+SELECT count(*)
+FROM buildings_bulk_load.removed
+WHERE building_outline_id = %s;
+"""
+
 # supplied dataset
 
 supplied_dataset_count_both_dates_are_null = """
@@ -298,6 +313,14 @@ supplied_dataset_description_by_dataset_id = """
 SELECT description
 FROM buildings_bulk_load.supplied_datasets sd
 WHERE sd.supplied_dataset_id = %s;
+"""
+
+supplied_dataset_latest_id_and_dates = """
+SELECT supplied_dataset_id, processed_date, transfer_date
+FROM buildings_bulk_load.supplied_datasets
+WHERE supplied_dataset_id = (SELECT
+  MAX(supplied_dataset_id)
+  FROM buildings_bulk_load.supplied_datasets);
 """
 
 supplied_dataset_processed_date_by_dataset_id = """

--- a/buildings/sql/buildings_select_statements.py
+++ b/buildings/sql/buildings_select_statements.py
@@ -3,6 +3,7 @@
 Buildings Select Statements
 
 - building_outlines
+    - building_id_by_building_outline_id (building_outline_id)
     - building_outlines
     - building_outlines_capture_method_id_by_building_outline_id (building+putline_id)
     - building_outlines_end_lifespan_by_building_outline_id (building_outline_id)
@@ -20,6 +21,12 @@ Buildings Select Statements
 """
 
 # building outlines
+
+building_id_by_building_outline_id = """
+SELECT building_id
+FROM buildings.building_outlines
+WHERE building_outline_id = %s;
+"""
 
 building_outlines = """
 SELECT *

--- a/buildings/tests/gui/test_processes_edit_attribute_production.py
+++ b/buildings/tests/gui/test_processes_edit_attribute_production.py
@@ -15,7 +15,6 @@
 
  ***************************************************************************/
 """
-
 import unittest
 
 from PyQt4.QtCore import Qt
@@ -467,3 +466,79 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
         self.assertFalse(self.production_frame.cmb_ta.isEnabled())
         self.assertFalse(self.production_frame.cmb_town.isEnabled())
         self.assertFalse(self.production_frame.cmb_suburb.isEnabled())
+
+    def test_end_lifespan_of_building_pass(self):
+        """test that ending lifespan of removed building works"""
+        widget = iface.mapCanvas().viewport()
+        canvas_point = QgsMapTool(iface.mapCanvas()).toCanvasCoordinates
+        QTest.mouseClick(widget, Qt.RightButton,
+                         pos=canvas_point(QgsPoint(1878035.0, 5555256.0)),
+                         delay=50)
+        canvas = iface.mapCanvas()
+        selectedcrs = "EPSG:2193"
+        target_crs = QgsCoordinateReferenceSystem()
+        target_crs.createFromUserInput(selectedcrs)
+        canvas.setDestinationCrs(target_crs)
+        zoom_rectangle = QgsRectangle(1878035.0, 5555256.0,
+                                      1878345.0, 5555374.0)
+        canvas.setExtent(zoom_rectangle)
+        canvas.refresh()
+        QTest.mouseClick(widget, Qt.LeftButton,
+                         pos=canvas_point(QgsPoint(1878038.1, 5555312.6)),
+                         delay=30)
+
+        self.production_frame.change_instance.end_lifespan(False)
+        sql = 'SELECT end_lifespan FROM buildings.building_outlines WHERE building_outline_id = 1006;'
+        result = db._execute(sql)
+        self.assertNotEqual(result.fetchone()[0], None)
+        sql = 'SELECT end_lifespan FROM buildings.buildings WHERE building_id = 10006;'
+        result = db._execute(sql)
+        self.assertNotEqual(result.fetchone()[0], None)
+        sql = 'SELECT count(*) FROM buildings_bulk_load.existing_subset_extracts WHERE building_outline_id = 1006;'
+        result = db._execute(sql)
+        self.assertEquals(result.fetchone()[0], 0)
+        sql = 'SELECT count(*) FROM buildings_bulk_load.removed WHERE building_outline_id = 1006;'
+        result = db._execute(sql)
+        self.assertEquals(result.fetchone()[0], 0)
+        self.production_frame.db.rollback_open_cursor()
+        self.production_frame.ids = []
+        self.production_frame.building_outline_id = None
+        self.production_frame.building_layer.removeSelection()
+
+    def test_end_lifespan_of_building_fails(self):
+        """test that ending lifespan of related building fails"""
+        widget = iface.mapCanvas().viewport()
+        canvas_point = QgsMapTool(iface.mapCanvas()).toCanvasCoordinates
+        QTest.mouseClick(widget, Qt.RightButton,
+                         pos=canvas_point(QgsPoint(1878035.0, 5555256.0)),
+                         delay=50)
+        canvas = iface.mapCanvas()
+        selectedcrs = "EPSG:2193"
+        target_crs = QgsCoordinateReferenceSystem()
+        target_crs.createFromUserInput(selectedcrs)
+        canvas.setDestinationCrs(target_crs)
+        zoom_rectangle = QgsRectangle(1878035.0, 5555256.0,
+                                      1878345.0, 5555374.0)
+        canvas.setExtent(zoom_rectangle)
+        canvas.refresh()
+        QTest.mouseClick(widget, Qt.LeftButton,
+                         pos=canvas_point(QgsPoint(1878420.4, 5555426.8)),
+                         delay=30)
+        self.production_frame.change_instance.end_lifespan(False)
+        self.production_frame.error_dialog.close()
+        sql = 'SELECT end_lifespan FROM buildings.building_outlines WHERE building_outline_id = 1033;'
+        result = db._execute(sql)
+        self.assertEquals(result.fetchone()[0], None)
+        sql = 'SELECT end_lifespan FROM buildings.buildings WHERE building_id = 10033;'
+        result = db._execute(sql)
+        self.assertEquals(result.fetchone()[0], None)
+        sql = 'SELECT count(*) FROM buildings_bulk_load.existing_subset_extracts WHERE building_outline_id = 1033;'
+        result = db._execute(sql)
+        self.assertEquals(result.fetchone()[0], 1)
+        sql = 'SELECT count(*) FROM buildings_bulk_load.related WHERE building_outline_id = 1033;'
+        result = db._execute(sql)
+        self.assertEquals(result.fetchone()[0], 2)
+        self.production_frame.db.rollback_open_cursor()
+        self.production_frame.ids = []
+        self.production_frame.building_outline_id = None
+        self.production_frame.building_layer.removeSelection()

--- a/buildings/tests/gui/test_processes_edit_attribute_production.py
+++ b/buildings/tests/gui/test_processes_edit_attribute_production.py
@@ -17,7 +17,8 @@
 """
 import unittest
 
-from PyQt4.QtCore import Qt
+from PyQt4.QtCore import Qt, QTimer
+from PyQt4.QtGui import QMessageBox
 from PyQt4.QtTest import QTest
 from qgis.core import QgsCoordinateReferenceSystem, QgsPoint, QgsRectangle
 from qgis.gui import QgsMapTool
@@ -487,7 +488,10 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
                          pos=canvas_point(QgsPoint(1878038.1, 5555312.6)),
                          delay=30)
 
+        btn_yes = self.production_frame.change_instance.msgbox_remove.button(QMessageBox.Yes)
+        QTimer.singleShot(500, btn_yes.click)
         self.production_frame.change_instance.end_lifespan(False)
+
         sql = 'SELECT end_lifespan FROM buildings.building_outlines WHERE building_outline_id = 1006;'
         result = db._execute(sql)
         self.assertNotEqual(result.fetchone()[0], None)
@@ -524,6 +528,8 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
         QTest.mouseClick(widget, Qt.LeftButton,
                          pos=canvas_point(QgsPoint(1878420.4, 5555426.8)),
                          delay=30)
+        btn_yes = self.production_frame.change_instance.msgbox_remove.button(QMessageBox.Yes)
+        QTimer.singleShot(500, btn_yes.click)
         self.production_frame.change_instance.end_lifespan(False)
         self.production_frame.error_dialog.close()
         sql = 'SELECT end_lifespan FROM buildings.building_outlines WHERE building_outline_id = 1033;'

--- a/db/sql/buildings/functions/02-use.sql
+++ b/db/sql/buildings/functions/02-use.sql
@@ -1,9 +1,11 @@
 --------------------------------------------
 -- buildings.use
 
--- Future Enhancement
+-- use_update_end_lifespan (update the end_endlifespan of building in use table)
+    -- params: integer[], building_ids
+    -- return: number of outlines updated
 --------------------------------------------
 
 
 -- FUNCTIONS --
--- None
+--None

--- a/db/sql/buildings/functions/05-building_name.sql
+++ b/db/sql/buildings/functions/05-building_name.sql
@@ -4,4 +4,23 @@
 --------------------------------------------
 
 -- Functions
--- None
+
+-- building_name_update_end_lifespan (update the end_endlifespan of building in name table)
+    -- params: integer[], building_ids
+    -- return: number of outlines updated
+CREATE OR REPLACE FUNCTION buildings.building_name_update_end_lifespan(integer[])
+    RETURNS integer AS
+$$
+
+    WITH update_name AS (
+        UPDATE buildings.building_name
+        SET end_lifespan = now()
+        WHERE building_id = ANY($1)
+        RETURNING *
+    )
+    SELECT count(*)::integer FROM update_name;
+
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION buildings.building_name_update_end_lifespan(integer[]) IS
+'Update end_lifespan in building_name table';

--- a/db/sql/buildings/functions/06-building_use.sql
+++ b/db/sql/buildings/functions/06-building_use.sql
@@ -1,7 +1,29 @@
 --------------------------------------------
 -- buildings.building_use
--- future enhancement
+
+-- use_update_end_lifespan (update the end_endlifespan of building in use table)
+    -- params: integer[], building_ids
+    -- return: number of outlines updated
 --------------------------------------------
 
 -- Functions
--- None
+
+-- building_use_update_end_lifespan (update the end_endlifespan of building in use table)
+    -- params: integer[], building_ids
+    -- return: number of outlines updated
+CREATE OR REPLACE FUNCTION buildings.building_use_update_end_lifespan(integer[])
+    RETURNS integer AS
+$$
+
+    WITH update_use AS (
+        UPDATE buildings.building_use
+        SET end_lifespan = now()
+        WHERE building_id = ANY($1)
+        RETURNING *
+    )
+    SELECT count(*)::integer FROM update_use;
+
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION buildings.building_use_update_end_lifespan(integer[]) IS
+'Update end_lifespan in building use table';

--- a/db/sql/buildings_bulk_load/functions/06-existing_subset_extracts.sql
+++ b/db/sql/buildings_bulk_load/functions/06-existing_subset_extracts.sql
@@ -8,6 +8,10 @@
             -- geometry shape
     -- return: count of rows inserted into table
 
+-- existing_subset_extracts_remove_outline (remove existing outline from table as it has been deleted)
+    -- params: integer[] building_outline_id
+    -- return: intger number of outlines removed
+
 -- existing_subset_extracts_update_supplied_dataset (update supplied dataset id of existing subset extracts outline)
     -- params: integer supplied_dataset_id, integer building_outline_id
     -- return: count of outlines added (should only be one)
@@ -69,3 +73,22 @@ $$ LANGUAGE sql VOLATILE;
 
 COMMENT ON FUNCTION buildings_bulk_load.existing_subset_extracts_update_supplied_dataset(integer, integer) IS
 'Update supplied_dataset_id in existing_subset_extracts table';
+
+-- existing_subset_extracts_remove_outline (remove existing outline from table as it has been deleted)
+    -- params: integer[] building_outline_id
+    -- return: intger number of outlines removed
+CREATE OR REPLACE FUNCTION buildings_bulk_load.existing_subset_extracts_remove_by_building_outline_id(integer[])
+    RETURNS integer AS
+$$
+
+    WITH update_existing AS (
+        DELETE FROM buildings_bulk_load.existing_subset_extracts
+        WHERE building_outline_id = ANY($1)
+        RETURNING *
+    )
+    SELECT count(*)::integer FROM update_existing;
+
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION buildings_bulk_load.existing_subset_extracts_remove_by_building_outline_id(integer[]) IS
+'Remove outline from existin subset extracts table';

--- a/db/sql/buildings_bulk_load/functions/08-removed.sql
+++ b/db/sql/buildings_bulk_load/functions/08-removed.sql
@@ -77,7 +77,7 @@ COMMENT ON FUNCTION buildings_bulk_load.buildings_removed_select_by_dataset(inte
 -- removed_delete_existing_outline (delete outline from removed table)
     -- params: integer building_outline_id
     -- return: building_outline_id removed
-CREATE OR REPLACE FUNCTION buildings_bulk_load.removed_delete_existing_outlines(integer)
+CREATE OR REPLACE FUNCTION buildings_bulk_load.removed_delete_existing_outline(integer)
 RETURNS integer AS
 $$
 
@@ -88,7 +88,7 @@ $$
 $$
 LANGUAGE sql;
 
-COMMENT ON FUNCTION buildings_bulk_load.removed_delete_existing_outlines(integer) IS
+COMMENT ON FUNCTION buildings_bulk_load.removed_delete_existing_outline(integer) IS
 'Delete outline from removed table by building_outline_id';
 
 -- removed_delete_existing_outlines (delete from removed table mulitple outlines)

--- a/db/sql/buildings_bulk_load/functions/08-removed.sql
+++ b/db/sql/buildings_bulk_load/functions/08-removed.sql
@@ -15,9 +15,17 @@
     -- params: integer building_outline_id
     -- return: building_outline_id removed
 
+-- removed_delete_existing_outlines (delete from removed table mulitple outlines)
+    -- params: integer[], building_outline_ids
+    -- return: number of outlines updated
+
 -- removed_insert_building_outlines (insert new building outline entry into table)
     -- params: integer building_outline_id
     -- return: building_outline_id inserted
+
+-- removed_update_qa_status_id (update qa status of removed outlines)
+    -- params: integer qa_status, integer building_outline_id
+    -- return: count of outlines updated
 
 --------------------------------------------
 
@@ -83,6 +91,24 @@ LANGUAGE sql;
 COMMENT ON FUNCTION buildings_bulk_load.removed_delete_existing_outlines(integer) IS
 'Delete outline from removed table by building_outline_id';
 
+-- removed_delete_existing_outlines (delete from removed table mulitple outlines)
+    -- params: integer[], building_outline_ids
+    -- return: number of outlines updated
+CREATE OR REPLACE FUNCTION buildings_bulk_load.removed_delete_existing_outlines(integer[])
+    RETURNS integer AS
+$$
+
+    WITH update_removed AS (
+        DELETE FROM buildings_bulk_load.removed
+        WHERE building_outline_id = ANY($1)
+        RETURNING *
+    )
+    SELECT count(*)::integer FROM update_removed;
+
+$$ LANGUAGE sql;
+
+COMMENT ON FUNCTION buildings_bulk_load.removed_delete_existing_outlines(integer[]) IS
+'remove list of outlines from removed table';
 
 -- removed_insert_building_outlines (insert new building outline entry into table)
     -- params: integer building_outline_id


### PR DESCRIPTION
Fixes: #186 

### Change Description:
Button added to production frame allowing the user to end the lifespan of a building in production, when under then edit attribute option. 

The button will update the end lifespan field of the outline in the building_name, building_use, building_outlines and buildings tables as well as, if appropriate, remove the outline from the existing subset extracts and removed tables. The end lifespan button will give an error dialog if the outline is currently matched/related to an outline of the most recent bulk loaded dataset. The user can only end the lifespan of a building like this after the outlines have been 'unlinked'.

### Notes for Testing:


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [x] Added tests that fail without this change
- [x] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
