### PR TITLE
Fix external_source_id combo box populating error

### DIFF
--- a/buildings/gui/bulk_load.py
+++ b/buildings/gui/bulk_load.py
@@ -42,7 +42,7 @@ def populate_bulk_comboboxes(self):
     id_capture_src_grp = self.ids_capture_src_grp[index]
     result = self.db._execute(common_select.capture_source_by_group_id, (id_capture_src_grp, ))
     ls = result.fetchall()
-    for item in ls:
+    for item in reversed(ls):
         self.cmb_external_id.addItem(item[0])
 
 

--- a/buildings/gui/bulk_load.py
+++ b/buildings/gui/bulk_load.py
@@ -28,25 +28,22 @@ def populate_bulk_comboboxes(self):
 
     # capture source group
     self.cmb_capture_src_grp.clear()
-    result = self.db._execute(common_select.capture_source_group_value_description)
+    self.ids_capture_src_grp = []
+    result = self.db._execute(common_select.capture_source_group_id_value_description)
     ls = result.fetchall()
-    for item in ls:
-        text = str(item[0]) + '- ' + str(item[1])
+    for (id_capture_src_grp, value, description) in ls:
+        text = str(value) + '- ' + str(description)
         self.cmb_capture_src_grp.addItem(text)
+        self.ids_capture_src_grp.append(id_capture_src_grp)
 
-    # populates external source combobox when radiobutton is selected
-    result = self.db._execute(common_select.capture_source_external_source_id)
+    # external source combobox
+    self.cmb_external_id.clear()
+    index = self.cmb_capture_src_grp.currentIndex()
+    id_capture_src_grp = self.ids_capture_src_grp[index]
+    result = self.db._execute(common_select.capture_source_by_group_id, (id_capture_src_grp, ))
     ls = result.fetchall()
     for item in ls:
-        if item[0] is not None:
-            count = 0
-            exists = False
-            while count < self.cmb_external_id.count():
-                if self.cmb_external_id.itemText(count) == str(item[0]):
-                    exists = True
-                count = count + 1
-            if exists is False:
-                self.cmb_external_id.addItem(item[0])
+        self.cmb_external_id.addItem(item[0])
 
 
 def load_current_fields(self):

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -338,7 +338,7 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
         id_capture_src_grp = self.ids_capture_src_grp[index]
         result = self.db._execute(common_select.capture_source_by_group_id, (id_capture_src_grp, ))
         ls = result.fetchall()
-        for item in ls:
+        for item in reversed(ls):
             self.cmb_external_id.addItem(item[0])
 
     @pyqtSlot(bool)

--- a/buildings/gui/new_entry.py
+++ b/buildings/gui/new_entry.py
@@ -281,7 +281,7 @@ class NewEntry(QFrame, FORM_CLASS):
             sql = 'SELECT buildings_common.capture_source_group_insert(%s, %s);'
             result = self.db.execute_no_commit(
                 sql, (capture_source_group, description))
-            self.capture_method_id = result.fetchall()[0][0]
+            self.capture_source_group_id = result.fetchall()[0][0]
             if commit_status:
                 self.db.commit_open_cursor()
             self.le_new_entry.clear()

--- a/buildings/sql/buildings_common_select_statements.py
+++ b/buildings/sql/buildings_common_select_statements.py
@@ -110,6 +110,11 @@ SELECT value, description
 FROM buildings_common.capture_source_group;
 """
 
+capture_source_group_id_value_description = """
+SELECT capture_source_group_id, value, description
+FROM buildings_common.capture_source_group;
+"""
+
 capture_source_group_value_description_external_by_building_outline_id = """
 SELECT csg.value,
        csg.description,

--- a/buildings/tests/gui/test_processes_bulk_load_outlines.py
+++ b/buildings/tests/gui/test_processes_bulk_load_outlines.py
@@ -63,6 +63,8 @@ class ProcessBulkLoadTest(unittest.TestCase):
     def tearDown(self):
         """Runs after each test."""
         self.bulk_load_frame.btn_exit.click()
+        # rollback changes
+        self.bulk_load_frame.db.rollback_open_cursor()
 
     def test_external_id_radiobutton(self):
         """external source fields enable when external id radio button is enabled"""
@@ -109,9 +111,6 @@ class ProcessBulkLoadTest(unittest.TestCase):
             elif text == 'Test value':
                 self.assertEqual(self.bulk_load_frame.cmb_external_id.count(), 1)
 
-        # rollback changes
-        self.bulk_load_frame.db.rollback_open_cursor()
-
     def test_bulk_load_save_clicked(self):
         """When save is clicked data is added to the correct tables"""
         path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
@@ -145,7 +144,5 @@ class ProcessBulkLoadTest(unittest.TestCase):
         else:
             result = result.fetchall()[0][0]
         self.assertEqual(1, result)
-        # rollback changes
-        self.bulk_load_frame.db.rollback_open_cursor()
         # check supplied dataset is added
         self.assertIsNotNone(self.bulk_load_frame.current_dataset)

--- a/buildings/tests/gui/test_processes_bulk_load_outlines.py
+++ b/buildings/tests/gui/test_processes_bulk_load_outlines.py
@@ -97,7 +97,7 @@ class ProcessBulkLoadTest(unittest.TestCase):
         capture_source_group_id = result.fetchall()[0][0]
 
         sql = 'SELECT buildings_common.capture_source_insert(%s, %s);'
-        result = self.db.execute_no_commit(sql, (int(capture_source_group_id), '3'))
+        result = self.bulk_load_frame.db.execute_no_commit(sql, (int(capture_source_group_id), '3'))
 
         count = self.bulk_load_frame.cmb_capture_src_grp.count()
         for i in range(count):

--- a/buildings/tests/gui/test_processes_bulk_load_outlines.py
+++ b/buildings/tests/gui/test_processes_bulk_load_outlines.py
@@ -75,12 +75,6 @@ class ProcessBulkLoadTest(unittest.TestCase):
         self.bulk_load_frame.rad_external_id.click()
         # check restrictions have been removed
         self.assertTrue(self.bulk_load_frame.fcb_external_id.isEnabled())
-        self.assertTrue(self.bulk_load_frame.cmb_external_id.isEnabled())
-        # check external source id value is correctly populated
-        sql = 'SELECT COUNT(external_source_id) FROM buildings_common.capture_source;'
-        result3 = db._execute(sql)
-        result3 = result3.fetchall()[0][0]
-        self.assertEqual(self.bulk_load_frame.cmb_external_id.count(), result3)
         # check external id combobox populated with fields of current layer
         vectorlayer = self.bulk_load_frame.ml_outlines_layer.currentLayer()
         fields = vectorlayer.pendingFields()


### PR DESCRIPTION
Fixes: #188 

### Change Description:

During bulk loading new outlines, external source id combo box will change whenever capture source group combo box changed.

### Notes for Testing:

Test added in `test_processes_bulk_load_outlines`

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
