### PR TITLE
.ui file headers fix

### DIFF
--- a/makefile
+++ b/makefile
@@ -138,12 +138,11 @@ setup_test_db:
 	nz-buildings-load nz-buildings-plugin-db --with-plugin-setup; \
 	sed -i '4s/.*/dbname=nz-buildings-plugin-db/' ~/.qgis2/$(PLUGINNAME)/pg_config.ini
 
-check_ui_headers:
+update_ui_headers:
 	@echo
 	@echo "------------------------------------------"
 	@echo "Fix/revert header lines in .ui files to qgis.gui"
 	@echo "------------------------------------------"
 	for f in ./buildings/gui/*.ui; do \
-		sed -i.bak -e 's|<header>.*</header>|<header>qgis.gui</header>|g' $$f; \
-		rm $$f.bak; \
+		sed -i -e 's|<header>.*</header>|<header>qgis.gui</header>|g' $$f; \
 	done; \

--- a/makefile
+++ b/makefile
@@ -137,3 +137,13 @@ setup_test_db:
 	createdb $$PGDATABASE; \
 	nz-buildings-load nz-buildings-plugin-db --with-plugin-setup; \
 	sed -i '4s/.*/dbname=nz-buildings-plugin-db/' ~/.qgis2/$(PLUGINNAME)/pg_config.ini
+
+check_ui_headers:
+	@echo
+	@echo "------------------------------------------"
+	@echo "Fix/revert header lines in .ui files to qgis.gui"
+	@echo "------------------------------------------"
+	for f in ./buildings/gui/*.ui; do \
+		sed -i.bak -e 's|<header>.*</header>|<header>qgis.gui</header>|g' $$f; \
+		rm $$f.bak; \
+	done; \


### PR DESCRIPTION
Fixes: #185 

### Change Description:
when `make check_ui_headers` is run using the makefile all headers in the .ui files are updated/reverted to `<header>qgis.gui</header>`


### Notes for Testing:
To test change a header line in a .ui file, run `make check_ui_headers`, reload .ui file and code will change back to qgis.gui

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
