### PR TITLE
Add utility to help with incrementing the version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 
  * Topographic reference datasets can now be updated via LINZ Data Service changesets
  * Projection check for new capture source areas
+ * bump_version command in makefile
 
 1.0.6
 =====

--- a/makefile
+++ b/makefile
@@ -153,3 +153,17 @@ update_ui_headers:
 	for f in ./buildings/gui/*.ui; do \
 		sed -i -e 's|<header>.*</header>|<header>qgis.gui</header>|g' $$f; \
 	done; \
+
+bump_version:
+	@echo
+	@echo "------------------------------------------"
+	@echo "Bump version"
+	@echo "------------------------------------------"
+	# Update version number in QGIS Plugin
+	$(SED) -i 's/^version=.*/version=$(VERSION)/g' ./buildings/metadata.txt
+	# Add today's date for latest release in CHANGELOG
+	$(SED) -i '/Unreleased/{n;n;s/.*/$(TODAY)\n/}' ./CHANGELOG.rst
+	# Replace Unreleased header with version number in CHANGELOG
+	$(SED) -i 's/Unreleased/$(VERSION)/g' ./CHANGELOG.rst
+	# Replace version number in makefile
+	$(SED) -i 's/^VERSION = .*/VERSION = $(VERSION)/g' ./makefile

--- a/makefile
+++ b/makefile
@@ -143,7 +143,7 @@ setup_test_db:
 	dropdb --if-exists $$PGDATABASE; \
 	createdb $$PGDATABASE; \
 	nz-buildings-load nz-buildings-plugin-db --with-plugin-setup; \
-	sed -i '4s/.*/dbname=nz-buildings-plugin-db/' ~/.qgis2/$(PLUGINNAME)/pg_config.ini
+	$(SED) -i '4s/.*/dbname=nz-buildings-plugin-db/' ~/.qgis2/$(PLUGINNAME)/pg_config.ini
 
 update_ui_headers:
 	@echo
@@ -151,8 +151,8 @@ update_ui_headers:
 	@echo "Fix/revert header lines in .ui files to qgis.gui"
 	@echo "------------------------------------------"
 	for f in ./buildings/gui/*.ui; do \
-		sed -i -e 's|<header>.*</header>|<header>qgis.gui</header>|g' $$f; \
-	done; \
+		$(SED) -i -e 's|<header>.*</header>|<header>qgis.gui</header>|g' $$f; \
+	done;
 
 bump_version:
 	@echo


### PR DESCRIPTION
Fixes: #209

### Change Description:

Adds a utility to the makefile that updates the version number for the plugin, database and user.

### Notes for Testing:

`make bump_version TODAY=$(date '+%d-%m-%Y') VERSION=1.0.7` then check changes to files in git

#### Source Code Documentation Tasks:
- [x] CHANGELOG (Unreleased section) updated
- [x] Docstrings / comments included to help explain code

#### Testing Tasks:
- [x] All tests are passing in development environment
- [x] Reviewers assigned
- [x] Linked to main issue for ZenHub board
