### PR TITLE
Display capture source area title in combo box

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,18 @@ Change Log
 
 All notable changes to this project will be documented in this file.
 
-Unreleased
+Unreleased:rocket:
 ==========
 
-* Nothing - all up to date! :rocket:
+Changed
+-------
+
+* Display the name and id together in the capture source combo box.
+
+Fixed
+-----
+
+* Correctly populate capture source combo box when adding production outlines.
 
 1.2.0
 ==========

--- a/buildings/gui/bulk_load.py
+++ b/buildings/gui/bulk_load.py
@@ -12,6 +12,14 @@ def populate_bulk_comboboxes(self):
     """
         Populate bulk load comboboxes
     """
+
+    def fix_truncated_dropdown(cmb, text):
+        """
+            Fix the trucated cmb dropdown in windows
+        """
+        w = cmb.fontMetrics().boundingRect(text).width()
+        cmb.view().setFixedWidth(w + 30)
+
     # organisation combobox
     self.cmb_organisation.clear()
     result = self.db._execute(bulk_load_select.organisation_value)
@@ -31,10 +39,14 @@ def populate_bulk_comboboxes(self):
     self.ids_capture_src_grp = []
     result = self.db._execute(common_select.capture_source_group_id_value_description)
     ls = result.fetchall()
+    text_max = ''
     for (id_capture_src_grp, value, description) in ls:
         text = str(value) + '- ' + str(description)
         self.cmb_capture_src_grp.addItem(text)
         self.ids_capture_src_grp.append(id_capture_src_grp)
+        if len(text) > len(text_max):
+            text_max = text
+    fix_truncated_dropdown(self.cmb_capture_src_grp, text_max)
 
     # capture source area combobox
     self.cmb_cap_src_area.clear()
@@ -42,9 +54,13 @@ def populate_bulk_comboboxes(self):
     id_capture_src_grp = self.ids_capture_src_grp[index]
     result = self.db._execute(common_select.capture_source_external_id_and_area_title_by_group_id, (id_capture_src_grp, ))
     ls = result.fetchall()
+    text_max = ''
     for (external_id, area_title) in reversed(ls):
         text = external_id + '- ' + area_title
         self.cmb_cap_src_area.addItem(text)
+        if len(text) > len(text_max):
+            text_max = text
+    fix_truncated_dropdown(self.cmb_cap_src_area, text_max)
 
 
 def load_current_fields(self):

--- a/buildings/gui/bulk_load.py
+++ b/buildings/gui/bulk_load.py
@@ -40,10 +40,11 @@ def populate_bulk_comboboxes(self):
     self.cmb_external_id.clear()
     index = self.cmb_capture_src_grp.currentIndex()
     id_capture_src_grp = self.ids_capture_src_grp[index]
-    result = self.db._execute(common_select.capture_source_by_group_id, (id_capture_src_grp, ))
+    result = self.db._execute(common_select.capture_source_external_id_and_area_title_by_group_id, (id_capture_src_grp, ))
     ls = result.fetchall()
-    for item in reversed(ls):
-        self.cmb_external_id.addItem(item[0])
+    for (external_id, area_title) in reversed(ls):
+        text = external_id + '- ' + area_title
+        self.cmb_external_id.addItem(text)
 
 
 def load_current_fields(self):
@@ -172,7 +173,8 @@ def bulk_load(self, commit_status):
         )
         self.error_dialog.show()
         return
-    external_source_id = str(self.cmb_external_id.currentText())
+    text = str(self.cmb_external_id.currentText())
+    external_source_id = text.split('- ')[0]
 
     # capture source
     result = self.db._execute(

--- a/buildings/gui/bulk_load.py
+++ b/buildings/gui/bulk_load.py
@@ -36,15 +36,15 @@ def populate_bulk_comboboxes(self):
         self.cmb_capture_src_grp.addItem(text)
         self.ids_capture_src_grp.append(id_capture_src_grp)
 
-    # external source combobox
-    self.cmb_external_id.clear()
+    # capture source area combobox
+    self.cmb_cap_src_area.clear()
     index = self.cmb_capture_src_grp.currentIndex()
     id_capture_src_grp = self.ids_capture_src_grp[index]
     result = self.db._execute(common_select.capture_source_external_id_and_area_title_by_group_id, (id_capture_src_grp, ))
     ls = result.fetchall()
     for (external_id, area_title) in reversed(ls):
         text = external_id + '- ' + area_title
-        self.cmb_external_id.addItem(text)
+        self.cmb_cap_src_area.addItem(text)
 
 
 def load_current_fields(self):
@@ -79,8 +79,8 @@ def load_current_fields(self):
     ex_result = ex_result.fetchall()[0][0]
     if ex_result is not None:
         self.rad_external_id.setChecked(True)
-        self.cmb_external_id.setCurrentIndex(
-            self.cmb_external_id.findText(ex_result))
+        self.cmb_cap_src_area.setCurrentIndex(
+            self.cmb_cap_src_area.findText(ex_result))
 
     # capture source group
     result = self.db._execute(
@@ -162,9 +162,9 @@ def bulk_load(self, commit_status):
         common_select.capture_source_group_id_by_value, (text_ls[0],))
     capture_source_group = result.fetchall()[0][0]
 
-    # external source
+    # capture source area
 
-    if self.cmb_external_id.count() == 0:
+    if self.cmb_cap_src_area.count() == 0:
         self.error_dialog = ErrorDialog()
         self.error_dialog.fill_report(
             '\n -------------- NO CAPTURE SOURCE ENTRY EXISTS-------'
@@ -173,7 +173,7 @@ def bulk_load(self, commit_status):
         )
         self.error_dialog.show()
         return
-    text = str(self.cmb_external_id.currentText())
+    text = str(self.cmb_cap_src_area.currentText())
     external_source_id = text.split('- ')[0]
 
     # capture source

--- a/buildings/gui/bulk_load.ui
+++ b/buildings/gui/bulk_load.ui
@@ -426,12 +426,12 @@ QGroupBox::title {
           <item row="5" column="0">
            <widget class="QLabel" name="lb_external_id_2">
             <property name="text">
-             <string>External Source Id :</string>
+             <string>Capture Source Area:</string>
             </property>
            </widget>
           </item>
           <item row="5" column="1">
-           <widget class="QComboBox" name="cmb_external_id">
+           <widget class="QComboBox" name="cmb_cap_src_area">
             <property name="minimumSize">
              <size>
               <width>0</width>

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -47,9 +47,13 @@ class BulkLoadChanges:
             # populate capture source group
             result = self.bulk_load_frame.db._execute(common_select.capture_source_group_value_description_external)
             ls = result.fetchall()
+            text_max = ''
             for item in ls:
                 text = '- '.join(item)
                 self.bulk_load_frame.cmb_capture_source.addItem(text)
+                if len(text) > len(text_max):
+                    text_max = text
+            self.fix_truncated_dropdown(self.bulk_load_frame.cmb_capture_source, text_max)
 
             # populate territorial authority combobox
             result = self.bulk_load_frame.db._execute(
@@ -177,6 +181,13 @@ class BulkLoadChanges:
         self.bulk_load_frame.cmb_suburb.setDisabled(1)
         self.bulk_load_frame.btn_edit_save.setDisabled(1)
         self.bulk_load_frame.btn_edit_reset.setDisabled(1)
+
+    def fix_truncated_dropdown(self, cmb, text):
+        """
+            Fix the trucated cmb dropdown in windows
+        """
+        w = cmb.fontMetrics().boundingRect(text).width()
+        cmb.view().setFixedWidth(w + 30)
 
 
 class AddBulkLoad(BulkLoadChanges):

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -45,7 +45,7 @@ class BulkLoadChanges:
 
         if self.bulk_load_frame.layout_general_info.isVisible():
             # populate capture source group
-            result = self.bulk_load_frame.db._execute(common_select.capture_source_group_value_description_external)
+            result = self.bulk_load_frame.db._execute(common_select.capture_source_group_value_external)
             ls = result.fetchall()
             text_max = ''
             for item in ls:
@@ -113,9 +113,7 @@ class BulkLoadChanges:
             text = self.bulk_load_frame.cmb_capture_source.currentText()
             text_ls = text.split('- ')
             result = self.bulk_load_frame.db.execute_no_commit(
-                common_select.capture_source_group_by_value_and_description, (
-                    text_ls[2], text_ls[3]
-                ))
+                common_select.capture_source_group_id_by_value, (text_ls[2], ))
             data = result.fetchall()[0][0]
             if text_ls[0] == 'None':
                 result = self.bulk_load_frame.db.execute_no_commit(
@@ -422,7 +420,7 @@ class AddBulkLoad(BulkLoadChanges):
 
         # capture source
         result = self.bulk_load_frame.db._execute(
-            common_select.capture_source_group_value_desc_external_by_dataset_id,
+            common_select.capture_source_group_value_external_by_dataset_id,
             (self.bulk_load_frame.current_dataset, )
         )
         result = result.fetchall()[0]
@@ -700,7 +698,7 @@ class EditAttribute(BulkLoadChanges):
 
         # capture source
         result = self.bulk_load_frame.db._execute(
-            common_select.capture_source_group_value_description_external_by_bulk_outline_id, (
+            common_select.capture_source_group_value_external_by_bulk_outline_id, (
                 self.bulk_load_frame.bulk_load_outline_id,
             ))
         result = result.fetchall()[0]

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -48,7 +48,7 @@ class BulkLoadChanges:
             result = self.bulk_load_frame.db._execute(common_select.capture_source_group_value_description_external)
             ls = result.fetchall()
             for item in ls:
-                text = str(item[0]) + '- ' + str(item[1] + '- ' + str(item[2]))
+                text = '- '.join(ls)
                 self.bulk_load_frame.cmb_capture_source.addItem(text)
 
             # populate territorial authority combobox
@@ -110,16 +110,16 @@ class BulkLoadChanges:
             text_ls = text.split('- ')
             result = self.bulk_load_frame.db.execute_no_commit(
                 common_select.capture_source_group_by_value_and_description, (
-                    text_ls[0], text_ls[1]
+                    text_ls[2], text_ls[3]
                 ))
             data = result.fetchall()[0][0]
-            if text_ls[2] == 'None':
+            if text_ls[0] == 'None':
                 result = self.bulk_load_frame.db.execute_no_commit(
                     common_select.capture_source_id_by_capture_source_group_id_is_null, (data,))
             else:
                 result = self.bulk_load_frame.db.execute_no_commit(
                     common_select.capture_source_id_by_capture_source_group_id_and_external_source_id, (
-                        data, text_ls[2]
+                        data, text_ls[0]
                     ))
             capture_source_id = result.fetchall()[0][0]
 
@@ -415,7 +415,7 @@ class AddBulkLoad(BulkLoadChanges):
             (self.bulk_load_frame.current_dataset, )
         )
         result = result.fetchall()[0]
-        text = str(result[0]) + '- ' + str(result[1] + '- ' + str(result[2]))
+        text = '- '.join(result)
         self.bulk_load_frame.cmb_capture_source.setCurrentIndex(
             self.bulk_load_frame.cmb_capture_source.findText(text))
 
@@ -693,7 +693,7 @@ class EditAttribute(BulkLoadChanges):
                 self.bulk_load_frame.bulk_load_outline_id,
             ))
         result = result.fetchall()[0]
-        text = str(result[0]) + '- ' + str(result[1] + '- ' + str(result[2]))
+        text = '- '.join(result)
         self.bulk_load_frame.cmb_capture_source.setCurrentIndex(
             self.bulk_load_frame.cmb_capture_source.findText(text))
 

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -48,7 +48,7 @@ class BulkLoadChanges:
             result = self.bulk_load_frame.db._execute(common_select.capture_source_group_value_description_external)
             ls = result.fetchall()
             for item in ls:
-                text = '- '.join(ls)
+                text = '- '.join(item)
                 self.bulk_load_frame.cmb_capture_source.addItem(text)
 
             # populate territorial authority combobox

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -339,10 +339,11 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
     def cmb_capture_src_grp_changed(self, index):
         self.cmb_external_id.clear()
         id_capture_src_grp = self.ids_capture_src_grp[index]
-        result = self.db._execute(common_select.capture_source_by_group_id, (id_capture_src_grp, ))
+        result = self.db._execute(common_select.capture_source_external_id_and_area_title_by_group_id, (id_capture_src_grp, ))
         ls = result.fetchall()
-        for item in reversed(ls):
-            self.cmb_external_id.addItem(item[0])
+        for (external_id, area_title) in reversed(ls):
+            text = external_id + '- ' + area_title
+            self.cmb_external_id.addItem(text)
 
     @pyqtSlot(bool)
     def cb_bulk_load_clicked(self, checked):

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -211,7 +211,7 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
         self.fcb_external_id.setDisabled(1)
         self.cmb_capture_src_grp.setEnabled(1)
         self.cmb_capture_src_grp.setCurrentIndex(0)
-        self.cmb_external_id.setEnabled(1)
+        self.cmb_cap_src_area.setEnabled(1)
         self.le_data_description.setEnabled(1)
         self.le_data_description.clear()
         self.cmb_capture_method.setEnabled(1)
@@ -248,7 +248,7 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
         self.rad_external_id.setDisabled(1)
         self.fcb_external_id.setDisabled(1)
         self.cmb_capture_src_grp.setDisabled(1)
-        self.cmb_external_id.setDisabled(1)
+        self.cmb_cap_src_area.setDisabled(1)
         self.le_data_description.setDisabled(1)
         self.cmb_capture_method.setDisabled(1)
         self.cmb_organisation.setDisabled(1)
@@ -337,13 +337,13 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
 
     @pyqtSlot(int)
     def cmb_capture_src_grp_changed(self, index):
-        self.cmb_external_id.clear()
+        self.cmb_cap_src_area.clear()
         id_capture_src_grp = self.ids_capture_src_grp[index]
         result = self.db._execute(common_select.capture_source_external_id_and_area_title_by_group_id, (id_capture_src_grp, ))
         ls = result.fetchall()
         for (external_id, area_title) in reversed(ls):
             text = external_id + '- ' + area_title
-            self.cmb_external_id.addItem(text)
+            self.cmb_cap_src_area.addItem(text)
 
     @pyqtSlot(bool)
     def cb_bulk_load_clicked(self, checked):

--- a/buildings/gui/new_capture_source.py
+++ b/buildings/gui/new_capture_source.py
@@ -370,9 +370,9 @@ class NewCaptureSource(QFrame, FORM_CLASS):
         result = self.db._execute(common_select.capture_source_group_by_value_and_description, (value, description))
         capture_source_group_id = result.fetchall()[0][0]
 
-        result = self.db._execute(common_select.capture_source_by_group_id, (capture_source_group_id,))
+        result = self.db._execute(common_select.capture_source_group_value_description_external_by_bulk_outline_id, (capture_source_group_id,))
         to_add = True
-        for (external_source_id, ) in result.fetchall():
+        for (external_source_id, area_title) in result.fetchall():
             if external_source_id == external_source:
                 self.error_dialog = ErrorDialog()
                 self.error_dialog.fill_report(

--- a/buildings/gui/new_capture_source.py
+++ b/buildings/gui/new_capture_source.py
@@ -370,7 +370,7 @@ class NewCaptureSource(QFrame, FORM_CLASS):
         result = self.db._execute(common_select.capture_source_group_by_value_and_description, (value, description))
         capture_source_group_id = result.fetchall()[0][0]
 
-        result = self.db._execute(common_select.capture_source_group_value_description_external_by_bulk_outline_id, (capture_source_group_id,))
+        result = self.db._execute(common_select.capture_source_external_id_and_area_title_by_group_id, (capture_source_group_id,))
         to_add = True
         for (external_source_id, area_title) in result.fetchall():
             if external_source_id == external_source:

--- a/buildings/gui/production_changes.py
+++ b/buildings/gui/production_changes.py
@@ -51,9 +51,13 @@ class ProductionChanges:
             # populate capture source group
             result = self.production_frame.db._execute(common_select.capture_source_group_value_description_external)
             ls = result.fetchall()
+            text_max = ''
             for item in ls:
                 text = '- '.join(item)
                 self.production_frame.cmb_capture_source.addItem(text)
+                if len(text) > len(text_max):
+                    text_max = text
+            self.fix_truncated_dropdown(self.production_frame.cmb_capture_source, text_max)
 
             # populate lifecycle stage combobox
             result = self.production_frame.db._execute(buildings_select.lifecycle_stage_value)
@@ -183,6 +187,13 @@ class ProductionChanges:
         self.production_frame.btn_save.setDisabled(1)
         self.production_frame.btn_reset.setDisabled(1)
         self.production_frame.btn_end_lifespan.setDisabled(1)
+
+    def fix_truncated_dropdown(self, cmb, text):
+        """
+            Fix the trucated cmb dropdown in windows
+        """
+        w = cmb.fontMetrics().boundingRect(text).width()
+        cmb.view().setFixedWidth(w + 30)
 
 
 class AddProduction(ProductionChanges):
@@ -428,13 +439,18 @@ class AddProduction(ProductionChanges):
                 level=QgsMessageBar.INFO,
                 duration=6
             )
+            text_max = ''
             for item in result:
                 text = '- '.join(item)
                 self.production_frame.cmb_capture_source.addItem(text)
+                if len(text) > len(text_max):
+                    text_max = text
+            self.fix_truncated_dropdown(self.production_frame.cmb_capture_source, text_max)
             self.production_frame.cmb_capture_source.showPopup()
         else:
             text = '- '.join(result[0])
             self.production_frame.cmb_capture_source.addItem(text)
+            self.fix_truncated_dropdown(self.production_frame.cmb_capture_source, text)
 
         # territorial authority
         sql = 'SELECT buildings_reference.territorial_authority_intersect_polygon(%s);'

--- a/buildings/gui/production_changes.py
+++ b/buildings/gui/production_changes.py
@@ -409,30 +409,32 @@ class AddProduction(ProductionChanges):
             self.production_frame.cmb_capture_method.findText('Trace Orthophotography'))
 
         # capture source
+        # repopulate capture source cmb
+        self.production_frame.cmb_capture_source.clear()
         result = self.production_frame.db._execute(reference_select.capture_source_area_intersect_geom,
                                                    (self.production_frame.geom,))
         result = result.fetchall()
-        print result[0][0]
         if len(result) == 0:
             iface.messageBar().pushMessage(
                 'Capture Source',
-                'The new outline overlaps with no capture source area, please manually choose one.',
+                'The new outline overlaps with no capture source area, please reset.',
                 level=QgsMessageBar.WARNING,
-                duration=10
+                duration=6
             )
         elif len(result) > 1:
             iface.messageBar().pushMessage(
                 'Capture Source',
                 'The new outline overlaps with multiple capture source areas, please manually choose one.',
-                level=QgsMessageBar.WARNING,
-                duration=10
+                level=QgsMessageBar.INFO,
+                duration=6
             )
+            for item in result:
+                text = '- '.join(item)
+                self.production_frame.cmb_capture_source.addItem(text)
+            self.production_frame.cmb_capture_source.showPopup()
         else:
-            for index in range(self.production_frame.cmb_capture_source.count()):
-                text = self.production_frame.cmb_capture_source.itemText(index)
-                if text.split('-')[0] == result[0][0]:
-                    self.production_frame.cmb_capture_source.setCurrentIndex(index)
-                    break
+            text = '- '.join(result[0])
+            self.production_frame.cmb_capture_source.addItem(text)
 
         # territorial authority
         sql = 'SELECT buildings_reference.territorial_authority_intersect_polygon(%s);'

--- a/buildings/gui/production_changes.py
+++ b/buildings/gui/production_changes.py
@@ -52,7 +52,7 @@ class ProductionChanges:
             result = self.production_frame.db._execute(common_select.capture_source_group_value_description_external)
             ls = result.fetchall()
             for item in ls:
-                text = str(item[0]) + '- ' + str(item[1] + '- ' + str(item[2]))
+                text = '- '.join(item)
                 self.production_frame.cmb_capture_source.addItem(text)
 
             # populate lifecycle stage combobox
@@ -110,16 +110,16 @@ class ProductionChanges:
             text_ls = text.split('- ')
             result = self.production_frame.db.execute_no_commit(
                 common_select.capture_source_group_by_value_and_description, (
-                    text_ls[0], text_ls[1]
+                    text_ls[2], text_ls[3]
                 ))
             data = result.fetchall()[0][0]
-            if text_ls[2] == 'None':
+            if text_ls[0] == 'None':
                 result = self.production_frame.db.execute_no_commit(
                     common_select.capture_source_id_by_capture_source_group_id_is_null, (data,))
             else:
                 result = self.production_frame.db.execute_no_commit(
                     common_select.capture_source_id_by_capture_source_group_id_and_external_source_id, (
-                        data, text_ls[2]
+                        data, text_ls[0]
                     ))
             capture_source_id = result.fetchall()[0][0]
 
@@ -412,6 +412,7 @@ class AddProduction(ProductionChanges):
         result = self.production_frame.db._execute(reference_select.capture_source_area_intersect_geom,
                                                    (self.production_frame.geom,))
         result = result.fetchall()
+        print result[0][0]
         if len(result) == 0:
             iface.messageBar().pushMessage(
                 'Capture Source',
@@ -429,9 +430,9 @@ class AddProduction(ProductionChanges):
         else:
             for index in range(self.production_frame.cmb_capture_source.count()):
                 text = self.production_frame.cmb_capture_source.itemText(index)
-                if int(text.split('-')[-1]) == result[0][0]:
+                if text.split('-')[0] == result[0][0]:
+                    self.production_frame.cmb_capture_source.setCurrentIndex(index)
                     break
-            self.production_frame.cmb_capture_source.setCurrentIndex(index)
 
         # territorial authority
         sql = 'SELECT buildings_reference.territorial_authority_intersect_polygon(%s);'
@@ -714,7 +715,7 @@ class EditAttribute(ProductionChanges):
             (self.production_frame.building_outline_id,)
         )
         result = result.fetchall()[0]
-        text = str(result[0]) + '- ' + str(result[1] + '- ' + str(result[2]))
+        text = '- '.join(result)
         self.production_frame.cmb_capture_source.setCurrentIndex(
             self.production_frame.cmb_capture_source.findText(text))
 

--- a/buildings/gui/production_changes.py
+++ b/buildings/gui/production_changes.py
@@ -49,7 +49,7 @@ class ProductionChanges:
 
         if self.production_frame.layout_general_info.isVisible():
             # populate capture source group
-            result = self.production_frame.db._execute(common_select.capture_source_group_value_description_external)
+            result = self.production_frame.db._execute(common_select.capture_source_group_value_external)
             ls = result.fetchall()
             text_max = ''
             for item in ls:
@@ -113,9 +113,7 @@ class ProductionChanges:
             text = self.production_frame.cmb_capture_source.currentText()
             text_ls = text.split('- ')
             result = self.production_frame.db.execute_no_commit(
-                common_select.capture_source_group_by_value_and_description, (
-                    text_ls[2], text_ls[3]
-                ))
+                common_select.capture_source_group_id_by_value, (text_ls[2], ))
             data = result.fetchall()[0][0]
             if text_ls[0] == 'None':
                 result = self.production_frame.db.execute_no_commit(
@@ -729,7 +727,7 @@ class EditAttribute(ProductionChanges):
 
         # capture source
         result = self.production_frame.db._execute(
-            common_select.capture_source_group_value_description_external_by_building_outline_id,
+            common_select.capture_source_group_value_external_by_building_outline_id,
             (self.production_frame.building_outline_id,)
         )
         result = result.fetchall()[0]

--- a/buildings/sql/buildings_common_select_statements.py
+++ b/buildings/sql/buildings_common_select_statements.py
@@ -16,9 +16,10 @@ Buildings Common Select Statements:
   - capture_source_group_id_by_dataset_id (supplied_dataset_id)
   - capture_source_group_id_by_value (value)
   - capture_source_group_value_description
-  - capture_source_group_value_description_external
-  - capture_source_group_value_description_external_by_building_outline_id (building_outline_id)
-  - capture_source_group_value_description_external_by_bulk_outline_id (bulk_load_outline_id)
+  - capture_source_group_value_external
+  - capture_source_group_value_external_by_building_outline_id (building_outline_id)
+  - capture_source_group_value_external_by_bulk_outline_id (bulk_load_outline_id)
+  - capture_source_group_value_external_by_dataset_id (current_dataset_id)
 
 - Capture Source
   - capture_source_external_id_and_area_title_by_group_id (capture_source_group_id)
@@ -100,9 +101,10 @@ AND cs.capture_source_group_id = csg.capture_source_group_id;
 """
 
 capture_source_group_id_by_value = """
-SELECT capture_source_group_id
-FROM buildings_common.capture_source_group
-WHERE value = %s;
+SELECT csg.capture_source_group_id
+FROM buildings_common.capture_source_group csg
+JOIN buildings_common.capture_source cs USING (capture_source_group_id)
+WHERE csg.value = %s;
 """
 
 capture_source_group_value_description = """
@@ -115,11 +117,10 @@ SELECT capture_source_group_id, value, description
 FROM buildings_common.capture_source_group;
 """
 
-capture_source_group_value_description_external_by_building_outline_id = """
+capture_source_group_value_external_by_building_outline_id = """
 SELECT cs.external_source_id,
        csa.area_title,
-       csg.value,
-       csg.description
+       csg.value
 FROM buildings_common.capture_source_group csg
 JOIN buildings_common.capture_source cs USING (capture_source_group_id)
 JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id
@@ -127,11 +128,10 @@ JOIN buildings.building_outlines bo USING (capture_source_id)
 WHERE bo.building_outline_id = %s;
 """
 
-capture_source_group_value_description_external_by_bulk_outline_id = """
+capture_source_group_value_external_by_bulk_outline_id = """
 SELECT cs.external_source_id,
        csa.area_title,
-       csg.value,
-       csg.description
+       csg.value
 FROM buildings_common.capture_source_group csg
 JOIN buildings_common.capture_source cs USING (capture_source_group_id)
 JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id
@@ -139,21 +139,19 @@ JOIN buildings_bulk_load.bulk_load_outlines blo USING (capture_source_id)
 WHERE blo.bulk_load_outline_id = %s;
 """
 
-capture_source_group_value_description_external = """
+capture_source_group_value_external = """
 SELECT cs.external_source_id,
        csa.area_title,
-       csg.value,
-       csg.description
+       csg.value
 FROM buildings_common.capture_source_group csg
 JOIN buildings_common.capture_source cs USING (capture_source_group_id)
 JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id;
 """
 
-capture_source_group_value_desc_external_by_dataset_id = """
+capture_source_group_value_external_by_dataset_id = """
 SELECT cs.external_source_id,
        csa.area_title,
-       csg.value,
-       csg.description
+       csg.value
 FROM buildings_common.capture_source_group csg
 JOIN buildings_common.capture_source cs USING (capture_source_group_id)
 JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id

--- a/buildings/sql/buildings_common_select_statements.py
+++ b/buildings/sql/buildings_common_select_statements.py
@@ -116,44 +116,47 @@ FROM buildings_common.capture_source_group;
 """
 
 capture_source_group_value_description_external_by_building_outline_id = """
-SELECT csg.value,
-       csg.description,
-       cs.external_source_id
-FROM buildings_common.capture_source_group csg,
-     buildings_common.capture_source cs,
-     buildings.building_outlines bo
-WHERE csg.capture_source_group_id = cs.capture_source_group_id
-AND bo.capture_source_id = cs.capture_source_id
-AND bo.building_outline_id = %s;
+SELECT cs.external_source_id,
+       csa.area_title,
+       csg.value,
+       csg.description
+FROM buildings_common.capture_source_group csg
+JOIN buildings_common.capture_source cs USING (capture_source_group_id)
+JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id
+JOIN buildings.building_outlines bo USING (capture_source_id)
+WHERE bo.building_outline_id = %s;
 """
 
 capture_source_group_value_description_external_by_bulk_outline_id = """
-SELECT csg.value,
-       csg.description,
-       cs.external_source_id
-FROM buildings_common.capture_source_group csg,
-     buildings_common.capture_source cs,
-     buildings_bulk_load.bulk_load_outlines blo
-WHERE csg.capture_source_group_id = cs.capture_source_group_id
-AND blo.capture_source_id = cs.capture_source_id
-AND blo.bulk_load_outline_id = %s;
+SELECT cs.external_source_id,
+       csa.area_title,
+       csg.value,
+       csg.description
+FROM buildings_common.capture_source_group csg
+JOIN buildings_common.capture_source cs USING (capture_source_group_id)
+JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id
+JOIN buildings_bulk_load.bulk_load_outlines blo USING (capture_source_id)
+WHERE blo.bulk_load_outline_id = %s;
 """
 
 capture_source_group_value_description_external = """
-SELECT csg.value,
-       csg.description,
-       cs.external_source_id
-FROM buildings_common.capture_source_group csg,
-     buildings_common.capture_source cs
-WHERE cs.capture_source_group_id = csg.capture_source_group_id;
+SELECT cs.external_source_id,
+       csa.area_title,
+       csg.value,
+       csg.description
+FROM buildings_common.capture_source_group csg
+JOIN buildings_common.capture_source cs USING (capture_source_group_id)
+JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id;
 """
 
 capture_source_group_value_desc_external_by_dataset_id = """
-SELECT csg.value,
-       csg.description,
-       cs.external_source_id
+SELECT cs.external_source_id,
+       csa.area_title,
+       csg.value,
+       csg.description
 FROM buildings_common.capture_source_group csg
 JOIN buildings_common.capture_source cs USING (capture_source_group_id)
+JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id
 JOIN buildings_bulk_load.bulk_load_outlines blo USING (capture_source_id)
 WHERE blo.supplied_dataset_id = %s
 LIMIT 1;
@@ -161,10 +164,17 @@ LIMIT 1;
 
 # capture source
 
-capture_source_by_group_id = """
-SELECT external_source_id
-FROM buildings_common.capture_source
-WHERE buildings_common.capture_source.capture_source_group_id = %s;
+# capture_source_by_group_id = """
+# SELECT external_source_id
+# FROM buildings_common.capture_source
+# WHERE buildings_common.capture_source.capture_source_group_id = %s;
+# """
+
+capture_source_external_id_and_area_title_by_group_id = """
+SELECT cs.external_source_id, csa.area_title
+FROM buildings_common.capture_source cs
+JOIN buildings_reference.capture_source_area csa ON cs.external_source_id = csa.external_area_polygon_id
+WHERE cs.capture_source_group_id = %s;
 """
 
 capture_source_external_source_id_by_dataset_id = """
@@ -181,7 +191,7 @@ FROM buildings_common.capture_source;
 """
 
 capture_source_id_by_capture_source_group_id_and_external_source_id = """
-SELECT capture_source_id
+SELECT cs.capture_source_id
 FROM buildings_common.capture_source cs
 WHERE cs.capture_source_group_id = %s
 AND cs.external_source_id = %s;

--- a/buildings/sql/buildings_common_select_statements.py
+++ b/buildings/sql/buildings_common_select_statements.py
@@ -21,7 +21,7 @@ Buildings Common Select Statements:
   - capture_source_group_value_description_external_by_bulk_outline_id (bulk_load_outline_id)
 
 - Capture Source
-  - capture_source_by_group_id (capture_source_group_id)
+  - capture_source_external_id_and_area_title_by_group_id (capture_source_group_id)
   - capture_source_external_source_id
   - capture_source_external_source_id_by_dataset_id (dataset_id)
   - capture_source_id_by_capture_source_group_id_and_external_source_id (capture_source_group_id, external_source_id)
@@ -163,12 +163,6 @@ LIMIT 1;
 """
 
 # capture source
-
-# capture_source_by_group_id = """
-# SELECT external_source_id
-# FROM buildings_common.capture_source
-# WHERE buildings_common.capture_source.capture_source_group_id = %s;
-# """
 
 capture_source_external_id_and_area_title_by_group_id = """
 SELECT cs.external_source_id, csa.area_title

--- a/buildings/sql/buildings_reference_select_statements.py
+++ b/buildings/sql/buildings_reference_select_statements.py
@@ -60,8 +60,13 @@ WHERE area_title = %s;
 """
 
 capture_source_area_intersect_geom = """
-SELECT csa.external_area_polygon_id
+SELECT csa.external_area_polygon_id,
+       csa.area_title,
+       csg.value,
+       csg.description
 FROM buildings_reference.capture_source_area csa
+JOIN buildings_common.capture_source cs ON (csa.external_area_polygon_id = cs.external_source_id)
+JOIN buildings_common.capture_source_group csg USING (capture_source_group_id)
 WHERE ST_Intersects(csa.shape, %s::Geometry);
 """
 

--- a/buildings/sql/buildings_reference_select_statements.py
+++ b/buildings/sql/buildings_reference_select_statements.py
@@ -62,8 +62,7 @@ WHERE area_title = %s;
 capture_source_area_intersect_geom = """
 SELECT csa.external_area_polygon_id,
        csa.area_title,
-       csg.value,
-       csg.description
+       csg.value
 FROM buildings_reference.capture_source_area csa
 JOIN buildings_common.capture_source cs ON (csa.external_area_polygon_id = cs.external_source_id)
 JOIN buildings_common.capture_source_group csg USING (capture_source_group_id)

--- a/buildings/tests/gui/test_processes_add_bulk_load.py
+++ b/buildings/tests/gui/test_processes_add_bulk_load.py
@@ -102,7 +102,6 @@ class ProcessBulkAddOutlinesTest(unittest.TestCase):
             self.bulk_load_frame.cmb_capture_source.currentText(),
             '1- Imagery One- NZ Aerial Imagery'
         )
-        self.assertEqual(self.bulk_load_frame.cmb_capture_method.currentText(), 'Trace Orthophotography')
         self.assertEqual(self.bulk_load_frame.cmb_lifecycle_stage.currentText(), 'Current')
         self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Newtown')

--- a/buildings/tests/gui/test_processes_add_bulk_load.py
+++ b/buildings/tests/gui/test_processes_add_bulk_load.py
@@ -98,7 +98,16 @@ class ProcessBulkAddOutlinesTest(unittest.TestCase):
         self.assertTrue(self.bulk_load_frame.cmb_town.isEnabled())
         self.assertTrue(self.bulk_load_frame.cmb_suburb.isEnabled())
         self.assertEqual(self.bulk_load_frame.cmb_capture_method_2.currentText(), 'Trace Orthophotography')
-        self.bulk_load_frame.db.rollback_open_cursor()
+        self.assertEqual(
+            self.production_frame.cmb_capture_source.currentText(),
+            '1- Imagery One- NZ Aerial Imagery'
+        )
+        self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Trace Orthophotography')
+        self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
+        self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
+        self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Newtown')
+        self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
+        self.production_frame.db.rollback_open_cursor()
 
     def test_draw_circle_option(self):
         """Allows user to draw circle using circle button"""

--- a/buildings/tests/gui/test_processes_add_bulk_load.py
+++ b/buildings/tests/gui/test_processes_add_bulk_load.py
@@ -102,7 +102,6 @@ class ProcessBulkAddOutlinesTest(unittest.TestCase):
             self.bulk_load_frame.cmb_capture_source.currentText(),
             '1- Imagery One- NZ Aerial Imagery'
         )
-        self.assertEqual(self.bulk_load_frame.cmb_lifecycle_stage.currentText(), 'Current')
         self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Newtown')
         self.assertEqual(self.bulk_load_frame.cmb_town.currentText(), 'Wellington')

--- a/buildings/tests/gui/test_processes_add_bulk_load.py
+++ b/buildings/tests/gui/test_processes_add_bulk_load.py
@@ -99,15 +99,15 @@ class ProcessBulkAddOutlinesTest(unittest.TestCase):
         self.assertTrue(self.bulk_load_frame.cmb_suburb.isEnabled())
         self.assertEqual(self.bulk_load_frame.cmb_capture_method_2.currentText(), 'Trace Orthophotography')
         self.assertEqual(
-            self.production_frame.cmb_capture_source.currentText(),
+            self.bulk_load_frame.cmb_capture_source.currentText(),
             '1- Imagery One- NZ Aerial Imagery'
         )
-        self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Trace Orthophotography')
-        self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
-        self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
-        self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Newtown')
-        self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
-        self.production_frame.db.rollback_open_cursor()
+        self.assertEqual(self.bulk_load_frame.cmb_capture_method.currentText(), 'Trace Orthophotography')
+        self.assertEqual(self.bulk_load_frame.cmb_lifecycle_stage.currentText(), 'Current')
+        self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
+        self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Newtown')
+        self.assertEqual(self.bulk_load_frame.cmb_town.currentText(), 'Wellington')
+        self.bulk_load_frame.db.rollback_open_cursor()
 
     def test_draw_circle_option(self):
         """Allows user to draw circle using circle button"""

--- a/buildings/tests/gui/test_processes_add_production.py
+++ b/buildings/tests/gui/test_processes_add_production.py
@@ -105,7 +105,7 @@ class ProcessProductionAddOutlinesTest(unittest.TestCase):
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Trace Orthophotography')
         self.assertEqual(
             self.production_frame.cmb_capture_source.currentText(),
-            '1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/'
+            '1- Imagery One- NZ Aerial Imagery'
         )
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Trace Orthophotography')
         self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')

--- a/buildings/tests/gui/test_processes_add_production.py
+++ b/buildings/tests/gui/test_processes_add_production.py
@@ -103,6 +103,15 @@ class ProcessProductionAddOutlinesTest(unittest.TestCase):
         self.assertTrue(self.production_frame.cmb_suburb.isEnabled())
         self.assertTrue(self.production_frame.cmb_lifecycle_stage.isEnabled())
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Trace Orthophotography')
+        self.assertEqual(
+            self.production_frame.cmb_capture_source.currentText(),
+            '1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/'
+        )
+        self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Trace Orthophotography')
+        self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
+        self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
+        self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Newtown')
+        self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
         self.production_frame.db.rollback_open_cursor()
 
     def test_draw_circle_option(self):

--- a/buildings/tests/gui/test_processes_bulk_load_outlines.py
+++ b/buildings/tests/gui/test_processes_bulk_load_outlines.py
@@ -70,7 +70,7 @@ class ProcessBulkLoadTest(unittest.TestCase):
         """external source fields enable when external id radio button is enabled"""
         # checks on starting the restrictions are in place
         self.assertFalse(self.bulk_load_frame.fcb_external_id.isEnabled())
-        self.assertTrue(self.bulk_load_frame.cmb_external_id.isEnabled())
+        self.assertTrue(self.bulk_load_frame.cmb_cap_src_area.isEnabled())
         # click the radio button
         self.bulk_load_frame.rad_external_id.click()
         # check restrictions have been removed
@@ -83,10 +83,10 @@ class ProcessBulkLoadTest(unittest.TestCase):
         # check on unclicking radio button the restrictions are restablished
         self.bulk_load_frame.rad_external_id.click()
         self.assertFalse(self.bulk_load_frame.fcb_external_id.isEnabled())
-        self.assertTrue(self.bulk_load_frame.cmb_external_id.isEnabled())
+        self.assertTrue(self.bulk_load_frame.cmb_cap_src_area.isEnabled())
 
     def test_cmb_capture_src_grp_changed(self):
-        """When cmb_capture_src_grp changes cmb_external_id is re-populated"""
+        """When cmb_capture_src_grp changes cmb_cap_src_area is re-populated"""
         self.bulk_load_frame.db.open_cursor()
         sql = 'SELECT buildings_common.capture_source_group_insert(%s, %s);'
         result = self.bulk_load_frame.db.execute_no_commit(sql, ('Test value', 'Test description'))
@@ -101,9 +101,9 @@ class ProcessBulkLoadTest(unittest.TestCase):
             text = self.bulk_load_frame.cmb_capture_src_grp.currentText()
             text = text.split('-')[0]
             if text == 'NZ Aerial Imagery':
-                self.assertEqual(self.bulk_load_frame.cmb_external_id.count(), 2)
+                self.assertEqual(self.bulk_load_frame.cmb_cap_src_area.count(), 2)
             elif text == 'Test value':
-                self.assertEqual(self.bulk_load_frame.cmb_external_id.count(), 1)
+                self.assertEqual(self.bulk_load_frame.cmb_cap_src_area.count(), 1)
 
     def test_bulk_load_save_clicked(self):
         """When save is clicked data is added to the correct tables"""

--- a/buildings/tests/gui/test_processes_comparison.py
+++ b/buildings/tests/gui/test_processes_comparison.py
@@ -66,6 +66,9 @@ class ProcessComparison(unittest.TestCase):
                 self.bulk_load_frame.ml_outlines_layer.setLayer(self.bulk_load_frame.ml_outlines_layer.layer(idx))
                 break
             idx = idx + 1
+        # select capture source area
+        self.bulk_load_frame.cmb_external_id.setCurrentIndex(
+            self.bulk_load_frame.cmb_external_id.findText('1- Imagery One'))
         # add description
         self.bulk_load_frame.le_data_description.setText('Test bulk load outlines')
         # add outlines

--- a/buildings/tests/gui/test_processes_comparison.py
+++ b/buildings/tests/gui/test_processes_comparison.py
@@ -67,8 +67,8 @@ class ProcessComparison(unittest.TestCase):
                 break
             idx = idx + 1
         # select capture source area
-        self.bulk_load_frame.cmb_external_id.setCurrentIndex(
-            self.bulk_load_frame.cmb_external_id.findText('1- Imagery One'))
+        self.bulk_load_frame.cmb_cap_src_area.setCurrentIndex(
+            self.bulk_load_frame.cmb_cap_src_area.findText('1- Imagery One'))
         # add description
         self.bulk_load_frame.le_data_description.setText('Test bulk load outlines')
         # add outlines

--- a/buildings/tests/gui/test_processes_comparison_not_intersect.py
+++ b/buildings/tests/gui/test_processes_comparison_not_intersect.py
@@ -68,7 +68,8 @@ class ProcessComparisonNotIntersectTest(unittest.TestCase):
             idx = idx + 1
         # add description
         self.bulk_load_frame.le_data_description.setText('Test bulk load outlines')
-        self.bulk_load_frame.cmb_external_id.setCurrentIndex(self.bulk_load_frame.cmb_external_id.findText('2'))
+        self.bulk_load_frame.cmb_external_id.setCurrentIndex(
+            self.bulk_load_frame.cmb_external_id.findText('2- Imagery Two'))
         # add outlines
         btn_yes = self.bulk_load_frame.msgbox_bulk_load.button(QMessageBox.Yes)
         QTimer.singleShot(500, btn_yes.click)

--- a/buildings/tests/gui/test_processes_comparison_not_intersect.py
+++ b/buildings/tests/gui/test_processes_comparison_not_intersect.py
@@ -68,8 +68,8 @@ class ProcessComparisonNotIntersectTest(unittest.TestCase):
             idx = idx + 1
         # add description
         self.bulk_load_frame.le_data_description.setText('Test bulk load outlines')
-        self.bulk_load_frame.cmb_external_id.setCurrentIndex(
-            self.bulk_load_frame.cmb_external_id.findText('2- Imagery Two'))
+        self.bulk_load_frame.cmb_cap_src_area.setCurrentIndex(
+            self.bulk_load_frame.cmb_cap_src_area.findText('2- Imagery Two'))
         # add outlines
         btn_yes = self.bulk_load_frame.msgbox_bulk_load.button(QMessageBox.Yes)
         QTimer.singleShot(500, btn_yes.click)

--- a/buildings/tests/gui/test_processes_edit_attribute_bulk_load.py
+++ b/buildings/tests/gui/test_processes_edit_attribute_bulk_load.py
@@ -90,7 +90,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.bulk_load_frame.cmb_status.currentText(), 'Supplied')
         self.assertEqual(self.bulk_load_frame.cmb_capture_method_2.currentText(), 'Feature Extraction')
         self.assertEqual(self.bulk_load_frame.cmb_capture_source.currentText(),
-                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
+                         u'1- Imagery One- NZ Aerial Imagery')
         self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Aro Valley')
@@ -130,7 +130,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.bulk_load_frame.cmb_status.currentText(), 'Supplied')
         self.assertEqual(self.bulk_load_frame.cmb_capture_method_2.currentText(), 'Feature Extraction')
         self.assertEqual(self.bulk_load_frame.cmb_capture_source.currentText(),
-                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
+                         u'1- Imagery One- NZ Aerial Imagery')
         self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Aro Valley')
@@ -182,7 +182,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.bulk_load_frame.cmb_status.currentText(), 'Supplied')
         self.assertEqual(self.bulk_load_frame.cmb_capture_method_2.currentText(), 'Feature Extraction')
         self.assertEqual(self.bulk_load_frame.cmb_capture_source.currentText(),
-                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
+                         u'1- Imagery One- NZ Aerial Imagery')
         self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Kelburn')

--- a/buildings/tests/gui/test_processes_edit_attribute_bulk_load.py
+++ b/buildings/tests/gui/test_processes_edit_attribute_bulk_load.py
@@ -90,7 +90,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.bulk_load_frame.cmb_status.currentText(), 'Supplied')
         self.assertEqual(self.bulk_load_frame.cmb_capture_method_2.currentText(), 'Feature Extraction')
         self.assertEqual(self.bulk_load_frame.cmb_capture_source.currentText(),
-                         u'NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/- 1')
+                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
         self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Aro Valley')
@@ -130,7 +130,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.bulk_load_frame.cmb_status.currentText(), 'Supplied')
         self.assertEqual(self.bulk_load_frame.cmb_capture_method_2.currentText(), 'Feature Extraction')
         self.assertEqual(self.bulk_load_frame.cmb_capture_source.currentText(),
-                         u'NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/- 1')
+                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
         self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Aro Valley')
@@ -182,7 +182,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.bulk_load_frame.cmb_status.currentText(), 'Supplied')
         self.assertEqual(self.bulk_load_frame.cmb_capture_method_2.currentText(), 'Feature Extraction')
         self.assertEqual(self.bulk_load_frame.cmb_capture_source.currentText(),
-                         u'NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/- 1')
+                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
         self.assertEqual(self.bulk_load_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.bulk_load_frame.cmb_suburb.currentText(), 'Kelburn')

--- a/buildings/tests/gui/test_processes_edit_attribute_production.py
+++ b/buildings/tests/gui/test_processes_edit_attribute_production.py
@@ -87,7 +87,7 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Feature Extraction')
         self.assertEqual(self.production_frame.cmb_capture_source.currentText(),
-                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
+                         u'1- Imagery One- NZ Aerial Imagery')
         self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Aro Valley')
@@ -364,7 +364,7 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Feature Extraction')
         self.assertEqual(self.production_frame.cmb_capture_source.currentText(),
-                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
+                         u'1- Imagery One- NZ Aerial Imagery')
         self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Aro Valley')
@@ -417,7 +417,7 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Feature Extraction')
         self.assertEqual(self.production_frame.cmb_capture_source.currentText(),
-                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
+                         u'1- Imagery One- NZ Aerial Imagery')
         self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Kelburn')

--- a/buildings/tests/gui/test_processes_edit_attribute_production.py
+++ b/buildings/tests/gui/test_processes_edit_attribute_production.py
@@ -87,7 +87,7 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Feature Extraction')
         self.assertEqual(self.production_frame.cmb_capture_source.currentText(),
-                         u'NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/- 1')
+                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
         self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Aro Valley')
@@ -364,7 +364,7 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Feature Extraction')
         self.assertEqual(self.production_frame.cmb_capture_source.currentText(),
-                         u'NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/- 1')
+                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
         self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Aro Valley')
@@ -417,7 +417,7 @@ class ProcessProductionEditOutlinesTest(unittest.TestCase):
         self.assertEqual(self.production_frame.cmb_lifecycle_stage.currentText(), 'Current')
         self.assertEqual(self.production_frame.cmb_capture_method.currentText(), 'Feature Extraction')
         self.assertEqual(self.production_frame.cmb_capture_source.currentText(),
-                         u'NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/- 1')
+                         u'1- Imagery One- NZ Aerial Imagery- external_source_id will link to the imagery_survey_id from https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/')
         self.assertEqual(self.production_frame.cmb_ta.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_town.currentText(), 'Wellington')
         self.assertEqual(self.production_frame.cmb_suburb.currentText(), 'Kelburn')

--- a/buildings/tests/gui/test_processes_publish.py
+++ b/buildings/tests/gui/test_processes_publish.py
@@ -85,7 +85,7 @@ class ProcessPublish(unittest.TestCase):
         self.assertTrue(self.bulk_load_frame.le_data_description.isEnabled())
         self.assertFalse(self.bulk_load_frame.rad_external_id.isChecked())
         self.assertFalse(self.bulk_load_frame.fcb_external_id.isEnabled())
-        self.assertTrue(self.bulk_load_frame.cmb_external_id.isEnabled())
+        self.assertTrue(self.bulk_load_frame.cmb_cap_src_area.isEnabled())
         self.bulk_load_frame.db.rollback_open_cursor()
 
     def test_deleted_outlines_on_publish(self):

--- a/buildings/tests/gui/test_setup_bulk_load_outlines.py
+++ b/buildings/tests/gui/test_setup_bulk_load_outlines.py
@@ -60,8 +60,8 @@ class SetUpBulkLoadTest(unittest.TestCase):
     def test_external_defaults(self):
         """External source comboboxes disabled on setup"""
         self.assertFalse(self.bulk_load_frame.fcb_external_id.isEnabled())
-        self.assertTrue(self.bulk_load_frame.cmb_external_id.isEnabled())
-        self.assertEqual(self.bulk_load_frame.cmb_external_id.count(), 2)
+        self.assertTrue(self.bulk_load_frame.cmb_cap_src_area.isEnabled())
+        self.assertEqual(self.bulk_load_frame.cmb_cap_src_area.count(), 2)
 
     def test_supplied_layer_combobox(self):
         """Bulk load layer combobox contains only the layers in the qgis legend"""


### PR DESCRIPTION
Fixes: #247 

### Change Description:

Display the name and id of capture source area in the cmb in `bulk load frame` and `production frame`.

In `production frame`, the capture source combo box will update according to the location of the adding outlines and only show the intersecting capture source area(s). This attribute can be edit in `edit attribute` if needed.

Change `cmb_external_id` to `cmb_capture_source_area` to avoid confusion against `fcb_external_id`


### Notes for Testing:

Update tests, run all tests.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [x] CHANGELOG (Unreleased section) updated
- [x] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [x] Added tests that fail without this change
- [x] All tests are passing in development environment
- [x] Reviewers assigned
- [x] Linked to main issue for ZenHub board
