### PR TITLE
Bug fixed: "Not removed" outlines not being carried through while comparing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Unreleased
 
 * All up-to-date! :rocket:
 
+Fixed
+-----
+* Compare new dataset with previous dataset INCLUDING removed outlines that have "not removed" flag.
+
 1.3.0
 ==========
 26-03-2019

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,6 @@ All notable changes to this project will be documented in this file.
 Unreleased
 ==========
 
-* All up-to-date! :rocket:
-
 Fixed
 -----
 * Compare new dataset with previous dataset INCLUDING removed outlines that have "not removed" flag.

--- a/buildings/gui/comparisons.py
+++ b/buildings/gui/comparisons.py
@@ -16,7 +16,7 @@ def compare_outlines(self, commit_status):
     result = self.db.execute_no_commit(sql, (self.area_id,))
     hull = result.fetchall()[0][0]
 
-    result = self.db.execute_no_commit(buildings_select.building_outlines, (hull,))
+    result = self.db.execute_no_commit(buildings_select.building_outlines_intersect_geometry, (hull,))
     results = result.fetchall()
 
     if len(results) == 0:

--- a/buildings/sql/buildings_select_statements.py
+++ b/buildings/sql/buildings_select_statements.py
@@ -4,7 +4,7 @@ Buildings Select Statements
 
 - building_outlines
     - building_id_by_building_outline_id (building_outline_id)
-    - building_outlines
+    - building_outlines_intersect_geometry(geometry)
     - building_outlines_capture_method_id_by_building_outline_id (building+putline_id)
     - building_outlines_end_lifespan_by_building_outline_id (building_outline_id)
     - building_outline_shape_by_building_outline_id (building_outline_id)
@@ -28,11 +28,15 @@ FROM buildings.building_outlines
 WHERE building_outline_id = %s;
 """
 
-building_outlines = """
+building_outlines_intersect_geometry = """
 SELECT *
 FROM buildings.building_outlines bo
 WHERE ST_Intersects(bo.shape, %s)
-AND bo.building_outline_id NOT IN ( SELECT building_outline_id FROM buildings_bulk_load.removed );
+AND bo.building_outline_id NOT IN (
+    SELECT building_outline_id
+    FROM buildings_bulk_load.removed
+    WHERE qa_status_id != 5
+);
 """
 
 building_outlines_capture_method_id_by_building_outline_id = """


### PR DESCRIPTION
Fixes: #254 

### Change Description:

Fix one select_statement in the sql folder to fix the bug

### Notes for Testing:

Install the test data and publish
Bulk load the shapefile testdata, compare and click "copy&match"/"Not removed" button on one of the removed outlines
Bulk load the shapefile again and hit compare. See if the "not removed" outline can be seen in the relationship frame


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [x] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [x] Reviewers assigned
- [x] Linked to main issue for ZenHub board
