### PR TITLE
UNIQUE update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changed
 -------
 
 * Removed building_outline_id from nz_building_outlines to make it clear that building_id is the persistent id.
+* Account for UNIQUE constraints for data dictionary column parsing
 
 Fixed
 -----

--- a/db/docs/source/conf.py
+++ b/db/docs/source/conf.py
@@ -463,6 +463,11 @@ def get_columns(table_str, file_content, this_table_columns):
             "extra": "bold",
             "columns": [column_name_str, "integer", "32", " ", " ", "No"]
         },
+        "integer_unique_not_null": {
+            "regex": r"(.*)\sinteger\sUNIQUE\s.*",
+            "extra": "bold",
+            "columns": [column_name_str, "integer", "32", " ", " ", "No"]
+        },
         "primary_key_integer_not_null": {
             "regex": r"(.*)\sinteger(?=.*?(NOT NULL))(?=.*?(PRIMARY KEY))",
             "extra": "bold",


### PR DESCRIPTION
Fixes: #264 

Added data type in function "**get_columns**" called 
`"integer_unique_not_null".`
It should handle a integer column whether or not it also contains "null_null" or not.


Screenshot of correct result:
![image](https://user-images.githubusercontent.com/25912064/57050270-d8a17200-6ccf-11e9-9709-a2ad75dea2b7.png)

...



#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
