### PR TITLE
Warning messages on adding buildings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 
 * Compare new dataset with previous dataset INCLUDING removed outlines that have "not removed" flag.
 * Use the current time as the begin_lifespan of building outlines when creating them rather than the date of bulk loading
+* Warning messages for when multiple buildings are added at once
 
 1.3.0
 ==========

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -292,6 +292,10 @@ class AddBulkLoad(BulkLoadChanges):
            @param qgsfId:      Id of added feature
            @type  qgsfId:      qgis.core.QgsFeature.QgsFeatureId
         """
+        if self.bulk_load_frame.added_building_ids != []:
+            iface.messageBar().pushMessage("WARNING",
+                                           "You've drawn multiple outlines, only the LAST outline you've drawn will be saved.",
+                                           level=QgsMessageBar.WARNING, duration=3)
         if qgsfId not in self.bulk_load_frame.added_building_ids:
             self.bulk_load_frame.added_building_ids.append(qgsfId)
         # get new feature geom

--- a/buildings/gui/production_changes.py
+++ b/buildings/gui/production_changes.py
@@ -291,6 +291,10 @@ class AddProduction(ProductionChanges):
            @param qgsfId:      Id of added feature
            @type  qgsfId:      qgis.core.QgsFeature.QgsFeatureId
         """
+        if self.production_frame.added_building_ids != []:
+            iface.messageBar().pushMessage("WARNING",
+                                           "You've drawn multiple outlines, only the LAST outline you've drawn will be saved.",
+                                           level=QgsMessageBar.WARNING, duration=3)
         if qgsfId not in self.production_frame.added_building_ids:
             self.production_frame.added_building_ids.append(qgsfId)
         # get new feature geom


### PR DESCRIPTION
Fixes: #277 

### Change Description:
Warning messages added to bulk load and production frame when multiple outlines are added

### Notes for Testing:


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
