### PR TITLE
Edit dialog updates QA layer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Unreleased
 Added
 -----
 * buildings toolbar and bulk load adding/editing functionality added to the alter relationships frame
+* Update the error status and comment in the QA layer if bulk load outline edited (edit-geometry and delete-outline only)
 
 Changed
 -------

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -322,6 +322,9 @@ class AddBulkLoad(BulkLoadChanges):
         self.populate_edit_comboboxes()
         self.select_comboboxes_value()
 
+        self.edit_dialog.activateWindow()
+        self.edit_dialog.btn_edit_save.setDefault(True)
+
     @pyqtSlot(int)
     def creator_feature_deleted(self, qgsfId):
         """
@@ -861,6 +864,9 @@ class EditGeometry(BulkLoadChanges):
             self.enable_UI_functions()
             self.populate_edit_comboboxes()
             self.select_comboboxes_value()
+
+        self.edit_dialog.activateWindow()
+        self.edit_dialog.btn_edit_save.setDefault(True)
 
     def select_comboboxes_value(self):
         """

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -468,6 +468,8 @@ class EditAttribute(BulkLoadChanges):
             ls_relationships = self.remove_compared_outlines()
             if len(ls_relationships['matched']) == 0 and len(ls_relationships['related']) == 0:
                 if len(self.edit_dialog.ids) > 0:
+                    # Send signal to LIQA through edit dialog
+                    self.edit_dialog.delete_outline_saved.emit(self.edit_dialog.ids, self.edit_dialog.description_del)
                     for i in self.edit_dialog.ids:
                         # check current status of building
                         sql = bulk_load_select.bulk_load_status_id_by_outline_id
@@ -789,6 +791,8 @@ class EditGeometry(BulkLoadChanges):
         self.edit_dialog.db.open_cursor()
 
         _, capture_method_id, _, _, _, _ = self.get_comboboxes_values()
+
+        self.edit_dialog.edit_geometry_saved.emit(self.edit_dialog.geoms.keys())
 
         for key in self.edit_dialog.geoms:
             sql = 'SELECT buildings_bulk_load.bulk_load_outlines_update_shape(%s, %s);'

--- a/buildings/gui/edit_dialog.py
+++ b/buildings/gui/edit_dialog.py
@@ -4,7 +4,7 @@ from functools import partial
 import os
 
 from PyQt4 import uic
-from PyQt4.QtGui import QCompleter, QDialog
+from PyQt4.QtGui import QAbstractItemView, QCompleter, QDialog
 from PyQt4.QtCore import Qt, pyqtSignal, pyqtSlot
 
 from qgis.utils import iface, isPluginLoaded, plugins
@@ -330,6 +330,11 @@ class EditDialog(QDialog, FORM_CLASS):
             buildings_error_inspector = plugins['liqa'].building_outline_error_inspector
             try:
                 error_attribute_table = buildings_error_inspector.error_inspector.tbl_error_attr
+                selected_rows = error_attribute_table.selected_rows()
                 error_attribute_table._repopulate()
+                error_attribute_table.setSelectionMode(QAbstractItemView.MultiSelection)
+                for row in selected_rows:
+                    error_attribute_table.selectRow(row)
+                error_attribute_table.setSelectionMode(QAbstractItemView.ExtendedSelection)
             except AttributeError:
                 pass

--- a/buildings/gui/edit_dialog.py
+++ b/buildings/gui/edit_dialog.py
@@ -330,11 +330,12 @@ class EditDialog(QDialog, FORM_CLASS):
             buildings_error_inspector = plugins['liqa'].building_outline_error_inspector
             try:
                 error_attribute_table = buildings_error_inspector.error_inspector.tbl_error_attr
-                selected_rows = error_attribute_table.selected_rows()
-                error_attribute_table._repopulate()
-                error_attribute_table.setSelectionMode(QAbstractItemView.MultiSelection)
-                for row in selected_rows:
-                    error_attribute_table.selectRow(row)
-                error_attribute_table.setSelectionMode(QAbstractItemView.ExtendedSelection)
+                if error_attribute_table.isVisible():
+                    selected_rows = error_attribute_table.selected_rows()
+                    error_attribute_table._repopulate()
+                    error_attribute_table.setSelectionMode(QAbstractItemView.MultiSelection)
+                    for row in selected_rows:
+                        error_attribute_table.selectRow(row)
+                    error_attribute_table.setSelectionMode(QAbstractItemView.ExtendedSelection)
             except AttributeError:
                 pass

--- a/buildings/gui/edit_dialog.py
+++ b/buildings/gui/edit_dialog.py
@@ -5,9 +5,9 @@ import os
 
 from PyQt4 import uic
 from PyQt4.QtGui import QCompleter, QDialog
-from PyQt4.QtCore import Qt, pyqtSlot
+from PyQt4.QtCore import Qt, pyqtSignal, pyqtSlot
 
-from qgis.utils import iface
+from qgis.utils import iface, isPluginLoaded, plugins
 
 from buildings.gui import bulk_load_changes, production_changes
 from buildings.sql import buildings_bulk_load_select_statements as bulk_load_select
@@ -18,6 +18,9 @@ FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__), 'edit_dia
 
 
 class EditDialog(QDialog, FORM_CLASS):
+
+    edit_geometry_saved = pyqtSignal(list)
+    delete_outline_saved = pyqtSignal(list, str)
 
     def __init__(self, parent_frame, parent=None):
         super(EditDialog, self).__init__(parent)
@@ -33,6 +36,9 @@ class EditDialog(QDialog, FORM_CLASS):
         if self.parent_frame_name == 'BulkLoadFrame':
             self.editing_layer = self.parent_frame.bulk_load_layer
             self.current_dataset = self.parent_frame.current_dataset
+            # Update qa layers
+            self.edit_geometry_saved.connect(self.liqa_on_edit_geometry_saved)
+            self.delete_outline_saved.connect(self.liqa_on_delete_outline_saved)
         elif self.parent_frame_name == 'AlterRelationships':
             self.editing_layer = self.parent_frame.lyr_bulk_load
             self.current_dataset = self.parent_frame.current_dataset
@@ -281,3 +287,49 @@ class EditDialog(QDialog, FORM_CLASS):
         else:
             self.le_deletion_reason.setDisabled(1)
             self.le_deletion_reason.clear()
+
+    @pyqtSlot(list)
+    def liqa_on_edit_geometry_saved(self, ids):
+        for qa_lyr in self.find_qa_layer():
+            bulk_load_ids = self.get_bulk_load_ids(qa_lyr)
+            for feat_id in ids:
+                if feat_id in bulk_load_ids.values():
+                    qa_feat_id = bulk_load_ids.keys()[bulk_load_ids.values().index(feat_id)]
+                    self.update_qa_layer_attribute(qa_lyr, qa_feat_id, 'Fixed', 'Geometry edited')
+        self.repopulate_error_attribute_table()
+
+    @pyqtSlot(list, str)
+    def liqa_on_delete_outline_saved(self, ids, del_reason):
+        for qa_lyr in self.find_qa_layer():
+            bulk_load_ids = self.get_bulk_load_ids(qa_lyr)
+            for feat_id in ids:
+                if feat_id in bulk_load_ids.values():
+                    qa_feat_id = bulk_load_ids.keys()[bulk_load_ids.values().index(feat_id)]
+                    self.update_qa_layer_attribute(qa_lyr, qa_feat_id, 'Fixed', 'Deleted- {}'.format(del_reason))
+        self.repopulate_error_attribute_table()
+
+    def find_qa_layer(self):
+        for layer in iface.legendInterface().layers():
+            if layer.name().startswith('qa_'):
+                yield layer
+
+    def get_bulk_load_ids(self, qa_layer):
+        bulk_load_ids = {}
+        for feat in qa_layer.getFeatures():
+            bulk_load_ids[feat.id()] = feat['bulk_load_']
+        return bulk_load_ids
+
+    def update_qa_layer_attribute(self, qa_lyr, qa_id, error_status, comment):
+        qa_lyr.startEditing()
+        qa_lyr.changeAttributeValue(qa_id, 1, error_status, True)
+        qa_lyr.changeAttributeValue(qa_id, 2, comment, True)
+        qa_lyr.commitChanges()
+
+    def repopulate_error_attribute_table(self):
+        if isPluginLoaded('liqa'):
+            buildings_error_inspector = plugins['liqa'].building_outline_error_inspector
+            try:
+                error_attribute_table = buildings_error_inspector.error_inspector.tbl_error_attr
+                error_attribute_table._repopulate()
+            except AttributeError:
+                pass


### PR DESCRIPTION
Fixes: #293  

### Change Description:
In bulk load frame, when geometry is changed or outline is deleted QA layers (if exist) will be updated so users don't have to switch between building plugins to LIQA

Bonus: Edit dialog will be re-focused every time users add a outline or edit a geometry so changes can be simply saved by click `ENTER`.

### Notes for Testing:

No test has been updated.
- Run LIQA to create a qa layer. 
- Choose one of the features that have been picked up and `Edit geometry`. 
- Save the changes and open error inspector to see the update.
- Repeat the process for 'Delete outline'.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
