### PR TITLE
Split features while editing- Bulk Load

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Changed
 * Updated URL links
 * Changed editing functionality in bulk load to work through the buildings toolbar and use a popup dialog rather than be held in the frame
 * Changed editing functionality in production to work through the buildings toolbar and use a popup dialog rather than be held in the frame
+* Updated plugin editing functionality to allow the user to use the qgis split features tool and save the changes to the database
 
 Fixed
 -----

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -902,9 +902,13 @@ class EditGeometry(BulkLoadChanges):
                                            level=QgsMessageBar.INFO, duration=3)
         result = result.fetchall()
         if len(result) == 0:
-            iface.messageBar().pushMessage("INFO",
-                                           "You've tried to split the same feature twice, you must save the changes to the db between splitting the same feature.",
-                                           level=QgsMessageBar.INFO, duration=5)
+            self.error_dialog = ErrorDialog()
+            self.error_dialog.fill_report(
+                '\n -------- CANNOT SPLIT A NEWLY ADDED FEATURE ---'
+                '----- \n\nYou\'ve tried to split an outline that has just been created by split '
+                'you must first save this new outline to the db before splitting it again.'
+            )
+            self.error_dialog.show()
             self.disable_UI_functions()
             self.edit_dialog.btn_edit_reset.setEnabled(1)
             return
@@ -932,9 +936,14 @@ class EditGeometry(BulkLoadChanges):
         new_feature = next(self.editing_layer.getFeatures(request))
         self.new_attrs[qgsfId] = new_feature.attributes()
         if not self.new_attrs[qgsfId][5]:
-            iface.messageBar().pushMessage("INFO",
-                                           "You've added a new feature, this can't be done in edit geometry, please switch to add outline.",
-                                           level=QgsMessageBar.INFO, duration=5)
+            self.error_dialog = ErrorDialog()
+            self.error_dialog.fill_report(
+                '\n -------------------- CANNOT ADD NEW FEATURE ------'
+                '-------------- \n\nYou\'ve added a new feature, '
+                'this can\'t be done in edit geometry, '
+                'please switch to add outline.'
+            )
+            self.error_dialog.show()
             self.disable_UI_functions()
             self.edit_dialog.btn_edit_reset.setEnabled(1)
             return

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -804,12 +804,11 @@ class EditGeometry(BulkLoadChanges):
             # insert into bulk_load_outlines table
             for qgsfId, geom in self.edit_dialog.split_geoms.items():
                 attributes = self.new_attrs[qgsfId]
+                if not attributes[7]:
+                    attributes[7] = None
                 sql = 'SELECT buildings_bulk_load.bulk_load_outlines_insert(%s, NULL, 2, %s, %s, %s, %s, %s, %s);'
                 result = self.edit_dialog.db.execute_no_commit(
-                    sql, (self.edit_dialog.current_dataset, capture_method_id,
-                          attributes[5], attributes[6], attributes[7], attributes[8],
-                          geom)
-                )
+                    sql, (self.edit_dialog.current_dataset, capture_method_id, attributes[5], attributes[6], attributes[7], attributes[8], geom))
                 self.edit_dialog.outline_id = result.fetchall()[0][0]
 
                 # insert into added table

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -879,13 +879,15 @@ class EditGeometry(BulkLoadChanges):
         """
         # get new feature geom and convert to correct format
         result = self.edit_dialog.db._execute(bulk_load_select.bulk_load_status_id_by_outline_id, (qgsfId,))
-        if result.fetchone()[0] == 3:
-            iface.messageBar().pushMessage("INFO",
-                                           "You cannot edit the geometry of a removed outline.",
-                                           level=QgsMessageBar.INFO, duration=3)
-            self.disable_UI_functions()
-            self.edit_dialog.btn_edit_reset.setEnabled(1)
-            return
+        result = result.fetchone()
+        if result is not None:
+            if result[0] == 3:
+                iface.messageBar().pushMessage("INFO",
+                                               "You cannot edit the geometry of a removed outline.",
+                                               level=QgsMessageBar.INFO, duration=3)
+                self.disable_UI_functions()
+                self.edit_dialog.btn_edit_reset.setEnabled(1)
+                return
         wkt = geom.exportToWkt()
         sql = general_select.convert_geometry
         result = self.edit_dialog.db._execute(sql, (wkt,))

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -871,6 +871,14 @@ class EditGeometry(BulkLoadChanges):
            @type  geom:        qgis.core.QgsGeometry
         """
         # get new feature geom and convert to correct format
+        result = self.edit_dialog.db._execute(bulk_load_select.bulk_load_status_id_by_outline_id, (qgsfId,))
+        if result.fetchone()[0] == 3:
+            iface.messageBar().pushMessage("INFO",
+                                           "You cannot edit the geometry of a removed outline.",
+                                           level=QgsMessageBar.INFO, duration=3)
+            self.disable_UI_functions()
+            self.edit_dialog.btn_edit_reset.setEnabled(1)
+            return
         wkt = geom.exportToWkt()
         sql = general_select.convert_geometry
         result = self.edit_dialog.db._execute(sql, (wkt,))

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -903,9 +903,9 @@ class EditGeometry(BulkLoadChanges):
         if len(result) == 0:
             self.error_dialog = ErrorDialog()
             self.error_dialog.fill_report(
-                '\n -------- CANNOT SPLIT A NEWLY ADDED FEATURE ---'
-                '----- \n\nYou\'ve tried to split an outline that has just been created by split '
-                'you must first save this new outline to the db before splitting it again.'
+                '\n --- CANNOT SPLIT/EDIT A NEWLY ADDED FEATURE ---'
+                '\n\nYou\'ve tried to split/edit an outline that has just been created. '
+                'You must first save this new outline to the db before splitting/editing it again.'
             )
             self.error_dialog.show()
             self.disable_UI_functions()

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -481,6 +481,10 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
                     self.bulk_load_layer.geometryChanged.disconnect()
                 except TypeError:
                     pass
+                try:
+                    self.bulk_load_layer.featureAdded.disconnect()
+                except TypeError:
+                    pass
             elif isinstance(self.change_instance, bulk_load_changes.AddBulkLoad):
                 try:
                     self.bulk_load_layer.featureAdded.disconnect()

--- a/buildings/gui/edit_dialog.py
+++ b/buildings/gui/edit_dialog.py
@@ -50,6 +50,7 @@ class EditDialog(QDialog, FORM_CLASS):
         self.ids = []
         self.geoms = {}
         self.bulk_load_outline_id = None
+        self.split_geoms = []
 
         # processing class instances
         self.change_instance = None
@@ -223,6 +224,7 @@ class EditDialog(QDialog, FORM_CLASS):
         self.btn_edit_save.clicked.connect(partial(self.change_instance.edit_save_clicked, True))
         self.btn_edit_reset.clicked.connect(self.change_instance.edit_reset_clicked)
         self.editing_layer.geometryChanged.connect(self.change_instance.geometry_changed)
+        self.editing_layer.featureAdded.connect(self.change_instance.creator_feature_added)
 
         self.add_territorial_auth()
 
@@ -236,6 +238,8 @@ class EditDialog(QDialog, FORM_CLASS):
         self.ids = []
         self.building_outline_id = None
         self.geoms = {}
+        self.split_geoms = []
+        self.added_building_ids = []
 
         self.parent_frame.edit_cancel_clicked()
         for action in iface.building_toolbar.actions():

--- a/buildings/gui/edit_dialog.py
+++ b/buildings/gui/edit_dialog.py
@@ -56,7 +56,7 @@ class EditDialog(QDialog, FORM_CLASS):
         self.ids = []
         self.geoms = {}
         self.bulk_load_outline_id = None
-        self.split_geoms = []
+        self.split_geoms = {}
 
         # processing class instances
         self.change_instance = None
@@ -67,6 +67,7 @@ class EditDialog(QDialog, FORM_CLASS):
         self.completer_box()
 
         self.cmb_status.currentIndexChanged.connect(self.enable_le_deletion_reason)
+        self.rejected.connect(self.close_dialog)
 
     def init_dialog(self):
         self.layout_status.hide()
@@ -85,10 +86,6 @@ class EditDialog(QDialog, FORM_CLASS):
         self.btn_edit_save.setDisabled(1)
         self.btn_edit_reset.setDisabled(1)
         self.btn_end_lifespan.setDisabled(1)
-
-    def closeEvent(self, event):
-        self.close_dialog()
-        event.accept()
 
     def add_outline(self):
         self.setWindowTitle("Add Outline")
@@ -244,7 +241,7 @@ class EditDialog(QDialog, FORM_CLASS):
         self.ids = []
         self.building_outline_id = None
         self.geoms = {}
-        self.split_geoms = []
+        self.split_geoms = {}
         self.added_building_ids = []
 
         self.parent_frame.edit_cancel_clicked()

--- a/buildings/gui/production_changes.py
+++ b/buildings/gui/production_changes.py
@@ -831,6 +831,10 @@ class EditGeometry(ProductionChanges):
             self.populate_edit_comboboxes()
             self.select_comboboxes_value()
 
+    @pyqtSlot(int)
+    def creator_feature_added(self, qgsfId):
+        pass  # Future Enhancement
+
     def select_comboboxes_value(self):
         """
             Select the correct combobox value for the geometry


### PR DESCRIPTION
Fixes: #290 

### Change Description:
The user is now able to use the QGIS Split Features tool ![image](https://user-images.githubusercontent.com/33814653/58513568-d90c2a80-81f3-11e9-8d83-8b4ffcea5975.png) while in 'edit geometry' of the buildings plugin. 

Previously the bulk_load_changed.EditGeometry class did not account for any added geometries and there when used the geometry was still updated but the new split geometry was not added. This has now been fixed. 

### Notes for Testing:
new tests added
@jducnuigeen can you please check this functionality matches what you requested to split geometries at planning? :slightly_smiling_face: 

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [x] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [x] Added tests that fail without this change
- [x] All tests are passing in development environment
- [x] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
