### PR TITLE
Fix the bug when reverting changes during add outlines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Fixed
 * Compare new dataset with previous dataset INCLUDING removed outlines that have "not removed" flag.
 * Use the current time as the begin_lifespan of building outlines when creating them rather than the date of bulk loading
 * Warning messages for when multiple buildings are added at once
+* Users can correctly remove added outlines or revert changes when adding multiple outlines with 'add outline' functionality.
 
 1.3.0
 ==========

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -855,6 +855,7 @@ class EditGeometry(BulkLoadChanges):
             self.new_attrs = {}
             iface.actionCancelEdits().trigger()
             iface.actionToggleEditing().trigger()
+            iface.actionNodeTool().trigger()
 
     @pyqtSlot()
     def edit_reset_clicked(self):

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -853,7 +853,6 @@ class EditGeometry(BulkLoadChanges):
             self.edit_dialog.geoms = {}
             self.edit_dialog.split_geoms = {}
             self.new_attrs = {}
-            self.edit_dialog.added_building_ids = []
             iface.actionCancelEdits().trigger()
             iface.actionToggleEditing().trigger()
 
@@ -868,7 +867,6 @@ class EditGeometry(BulkLoadChanges):
         self.edit_dialog.geoms = {}
         self.edit_dialog.split_geoms = {}
         self.new_attrs = {}
-        self.edit_dialog.added_building_ids = []
         # restart editing
         iface.actionToggleEditing().trigger()
         iface.actionNodeTool().trigger()
@@ -938,8 +936,6 @@ class EditGeometry(BulkLoadChanges):
 
     @pyqtSlot(int)
     def creator_feature_added(self, qgsfId):
-        if qgsfId not in self.edit_dialog.added_building_ids:
-            self.edit_dialog.added_building_ids.append(qgsfId)
         # get new feature geom
         request = QgsFeatureRequest().setFilterFid(qgsfId)
         new_feature = next(self.editing_layer.getFeatures(request))

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -853,9 +853,7 @@ class EditGeometry(BulkLoadChanges):
             self.edit_dialog.geoms = {}
             self.edit_dialog.split_geoms = {}
             self.new_attrs = {}
-            iface.actionCancelEdits().trigger()
-            iface.actionToggleEditing().trigger()
-            iface.actionNodeTool().trigger()
+            self.edit_dialog.editing_layer.triggerRepaint()
 
     @pyqtSlot()
     def edit_reset_clicked(self):

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from collections import OrderedDict
+
 from PyQt4.QtCore import pyqtSlot
 from PyQt4.QtGui import QToolButton
 from qgis.core import QgsFeatureRequest, QgsGeometry
@@ -240,10 +242,9 @@ class AddBulkLoad(BulkLoadChanges):
         sql = 'SELECT buildings_bulk_load.bulk_load_outlines_insert(%s, NULL, 2, %s, %s, %s, %s, %s, %s);'
         result = self.edit_dialog.db.execute_no_commit(
             sql, (self.edit_dialog.current_dataset, capture_method_id,
-                  capture_source_id, suburb, town, t_a,
-                  self.edit_dialog.geom)
+                  capture_source_id, suburb, town, t_a, self.edit_dialog.geom)
         )
-        self.edit_dialog.outline_id = result.fetchall()[0][0]
+        outline_id = result.fetchall()[0][0]
 
         # insert into added table
         result = self.edit_dialog.db._execute(
@@ -255,12 +256,12 @@ class AddBulkLoad(BulkLoadChanges):
         if processed_date:
             sql = 'SELECT buildings_bulk_load.added_insert_bulk_load_outlines(%s, %s);'
             self.edit_dialog.db.execute_no_commit(
-                sql, (self.edit_dialog.outline_id, 1))
+                sql, (outline_id, 1))
 
         if commit_status:
             self.edit_dialog.db.commit_open_cursor()
             self.edit_dialog.geom = None
-            self.edit_dialog.added_building_ids = []
+            self.edit_dialog.added_geoms = OrderedDict()
         # reset and disable comboboxes
         if self.parent_frame.polyline:
             self.parent_frame.polyline.reset()
@@ -287,7 +288,7 @@ class AddBulkLoad(BulkLoadChanges):
         if self.parent_frame.polyline:
             self.parent_frame.polyline.reset()
         self.edit_dialog.geom = None
-        self.edit_dialog.added_building_ids = []
+        self.edit_dialog.added_geoms = OrderedDict()
 
     @pyqtSlot(int)
     def creator_feature_added(self, qgsfId):
@@ -296,12 +297,10 @@ class AddBulkLoad(BulkLoadChanges):
            @param qgsfId:      Id of added feature
            @type  qgsfId:      qgis.core.QgsFeature.QgsFeatureId
         """
-        if self.edit_dialog.added_building_ids != []:
+        if self.edit_dialog.added_geoms != {}:
             iface.messageBar().pushMessage("WARNING",
                                            "You've drawn multiple outlines, only the LAST outline you've drawn will be saved.",
                                            level=QgsMessageBar.WARNING, duration=3)
-        if qgsfId not in self.edit_dialog.added_building_ids:
-            self.edit_dialog.added_building_ids.append(qgsfId)
         # get new feature geom
         request = QgsFeatureRequest().setFilterFid(qgsfId)
         new_feature = next(self.editing_layer.getFeatures(request))
@@ -316,7 +315,12 @@ class AddBulkLoad(BulkLoadChanges):
         wkt = new_geometry.exportToWkt()
         sql = general_select.convert_geometry
         result = self.edit_dialog.db._execute(sql, (wkt,))
-        self.edit_dialog.geom = result.fetchall()[0][0]
+        geom = result.fetchall()[0][0]
+
+        if qgsfId not in self.edit_dialog.added_geoms.keys():
+            self.edit_dialog.added_geoms[qgsfId] = geom
+            self.edit_dialog.geom = geom
+
         # enable & populate comboboxes
         self.enable_UI_functions()
         self.populate_edit_comboboxes()
@@ -332,13 +336,16 @@ class AddBulkLoad(BulkLoadChanges):
             @param qgsfId:      Id of deleted feature
             @type  qgsfId:      qgis.core.QgsFeature.QgsFeatureId
         """
-        if qgsfId in self.edit_dialog.added_building_ids:
-            self.edit_dialog.added_building_ids.remove(qgsfId)
+        if qgsfId in self.edit_dialog.added_geoms.keys():
+            del self.edit_dialog.added_geoms[qgsfId]
             if self.parent_frame.polyline is not None:
                 self.parent_frame.polyline.reset()
-            if self.edit_dialog.added_building_ids == []:
+            if self.edit_dialog.added_geoms == {}:
                 self.disable_UI_functions()
                 self.edit_dialog.geom = None
+            else:
+                self.edit_dialog.geom = self.edit_dialog.added_geoms.values()[-1]
+                self.select_comboboxes_value()
 
     @pyqtSlot(int, QgsGeometry)
     def creator_geometry_changed(self, qgsfId, geom):
@@ -349,7 +356,12 @@ class AddBulkLoad(BulkLoadChanges):
            @param geom:        geometry of added feature
            @type  geom:        qgis.core.QgsGeometry
         """
-        if qgsfId in self.edit_dialog.added_building_ids:
+        if qgsfId in self.edit_dialog.added_geoms.keys():
+            area = geom.area()
+            if area < 10:
+                iface.messageBar().pushMessage("INFO",
+                                               "You've edited the outline to less than 10sqm, are you sure this is correct?",
+                                               level=QgsMessageBar.INFO, duration=3)
             wkt = geom.exportToWkt()
             if not wkt:
                 self.disable_UI_functions()
@@ -357,12 +369,10 @@ class AddBulkLoad(BulkLoadChanges):
                 return
             sql = general_select.convert_geometry
             result = self.edit_dialog.db._execute(sql, (wkt,))
-            self.edit_dialog.geom = result.fetchall()[0][0]
-            area = geom.area()
-            if area < 10:
-                iface.messageBar().pushMessage("INFO",
-                                               "You've edited the outline to less than 10sqm, are you sure this is correct?",
-                                               level=QgsMessageBar.INFO, duration=3)
+            geom = result.fetchall()[0][0]
+            self.edit_dialog.added_geoms[qgsfId] = geom
+            if qgsfId == self.edit_dialog.added_geoms.keys()[-1]:
+                self.edit_dialog.geom = geom
         else:
             self.error_dialog = ErrorDialog()
             self.error_dialog.fill_report(

--- a/buildings/gui/edit_dialog.py
+++ b/buildings/gui/edit_dialog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from collections import OrderedDict
 from functools import partial
 import os
 
@@ -51,7 +51,7 @@ class EditDialog(QDialog, FORM_CLASS):
         self.init_dialog()
 
         # Bulk loadings & editing fields
-        self.added_building_ids = []
+        self.added_geoms = OrderedDict()
         self.geom = None
         self.ids = []
         self.geoms = {}
@@ -89,7 +89,7 @@ class EditDialog(QDialog, FORM_CLASS):
 
     def add_outline(self):
         self.setWindowTitle("Add Outline")
-        self.added_building_ids = []
+        self.added_geoms = OrderedDict()
         self.geom = None
         iface.actionCancelEdits().trigger()
         # reset toolbar
@@ -236,7 +236,7 @@ class EditDialog(QDialog, FORM_CLASS):
             When 'x' is clicked
         """
         self.change_instance = None
-        self.added_building_ids = []
+        self.added_geoms = OrderedDict()
         self.geom = None
         self.ids = []
         self.building_outline_id = None

--- a/buildings/tests/gui/test_processes_add_bulk_load.py
+++ b/buildings/tests/gui/test_processes_add_bulk_load.py
@@ -194,7 +194,7 @@ class ProcessBulkAddOutlinesTest(unittest.TestCase):
         # click reset button
         self.edit_dialog.btn_edit_reset.click()
         # check geom removed from canvas
-        self.assertEqual(len(self.edit_dialog.added_building_ids), 0)
+        self.assertEqual(len(self.edit_dialog.added_geoms.keys()), 0)
         # check comboxbox indexes reset to 0
         self.assertEqual(self.edit_dialog.cmb_capture_method.currentIndex(), -1)
         self.assertEqual(self.edit_dialog.cmb_capture_source.currentIndex(), -1)

--- a/buildings/tests/gui/test_processes_add_production.py
+++ b/buildings/tests/gui/test_processes_add_production.py
@@ -204,7 +204,7 @@ class ProcessProductionAddOutlinesTest(unittest.TestCase):
         # click reset button
         self.edit_dialog.btn_edit_reset.click()
         # check geom removed from canvas
-        self.assertEqual(len(self.edit_dialog.added_building_ids), 0)
+        self.assertEqual(len(self.edit_dialog.added_geoms.keys()), 0)
         # check comboxbox indexes reset to 0
         self.assertEqual(self.edit_dialog.cmb_capture_method.currentIndex(), -1)
         self.assertEqual(self.edit_dialog.cmb_capture_source.currentIndex(), -1)


### PR DESCRIPTION
Fixes: #282   

### Change Description:
When users add multiple outlines in one time, only the last one will be save. Previously when users tried to revert changes by ctrl+z or deleting, the last added outlines would be saved. The bug has been fixed by saving the id and geom of all added outlines in an `OrderedDict`. You can
- Click on `ctrl+z` to remove the last added outline. (need to click on the qgis main window as edit dialog will be on the top)
- Delete last added outline and save the previous outline.
- Edit the last added outline and save the new geometry.
- Edit any previous outline will be saved in the dictionary but will NOT be saved in the database if there's another outline added after it. You can remove the last one in order to save your changes.


### Notes for Testing:

Tests updated.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
