### PR TITLE
Pull out LIQA functionality from buildings plugin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 * Use the current time as the begin_lifespan of building outlines when creating them rather than the date of bulk loading
 * Warning messages for when multiple buildings are added at once
 * Users can correctly remove added outlines or revert changes when adding multiple outlines with 'add outline' functionality.
+* Remove functionality repopulate_error_attribute_table to LIQA plugin.
 
 1.3.0
 ==========

--- a/buildings/gui/edit_dialog.py
+++ b/buildings/gui/edit_dialog.py
@@ -297,7 +297,6 @@ class EditDialog(QDialog, FORM_CLASS):
                 if feat_id in bulk_load_ids.values():
                     qa_feat_id = bulk_load_ids.keys()[bulk_load_ids.values().index(feat_id)]
                     self.update_qa_layer_attribute(qa_lyr, qa_feat_id, 'Fixed', 'Geometry edited')
-        self.repopulate_error_attribute_table()
 
     @pyqtSlot(list, str)
     def liqa_on_delete_outline_saved(self, ids, del_reason):
@@ -307,7 +306,6 @@ class EditDialog(QDialog, FORM_CLASS):
                 if feat_id in bulk_load_ids.values():
                     qa_feat_id = bulk_load_ids.keys()[bulk_load_ids.values().index(feat_id)]
                     self.update_qa_layer_attribute(qa_lyr, qa_feat_id, 'Fixed', 'Deleted- {}'.format(del_reason))
-        self.repopulate_error_attribute_table()
 
     def find_qa_layer(self):
         for layer in iface.legendInterface().layers():
@@ -325,18 +323,3 @@ class EditDialog(QDialog, FORM_CLASS):
         qa_lyr.changeAttributeValue(qa_id, 1, error_status, True)
         qa_lyr.changeAttributeValue(qa_id, 2, comment, True)
         qa_lyr.commitChanges()
-
-    def repopulate_error_attribute_table(self):
-        if isPluginLoaded('liqa'):
-            buildings_error_inspector = plugins['liqa'].building_outline_error_inspector
-            try:
-                error_attribute_table = buildings_error_inspector.error_inspector.tbl_error_attr
-                if error_attribute_table.isVisible():
-                    selected_rows = error_attribute_table.selected_rows()
-                    error_attribute_table._repopulate()
-                    error_attribute_table.setSelectionMode(QAbstractItemView.MultiSelection)
-                    for row in selected_rows:
-                        error_attribute_table.selectRow(row)
-                    error_attribute_table.setSelectionMode(QAbstractItemView.ExtendedSelection)
-            except AttributeError:
-                pass


### PR DESCRIPTION
Fixes: https://github.com/linz/qgis-liqa-plugin/issues/222
Link to another PR: https://github.com/linz/qgis-liqa-plugin/pull/223

### Change Description:

In the code we use `_repopulate` from liqa plugin which could be easily broken if other devs change the name and at the moment we don't have a test for it. So I pulled out the function `repopulate_error_attribute_table` to LIQA

### Notes for Testing:

In LIQA, switch to branch `on_qa_layer_attribute_change` (has been merged into `master`) and 
- Run LIQA to create a qa layer.
- Choose one of the features that have been picked up and Edit geometry.
- Save the changes and open error inspector to see the update.
- Repeat the process for 'Delete outline'.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
