### PR TITLE
Fix sequence verify statements so that they actually verify sequences

### DIFF
--- a/db/sql/verify/buildings/schema_and_tables.sql
+++ b/db/sql/verify/buildings/schema_and_tables.sql
@@ -12,14 +12,12 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings.lifecycle_stage', 'lifecycle_stage_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings.lifecycle_stage', 'lifecycle_stage_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings" table '
-        '"lifecycle_stage" and column "lifecycle_stage_id" is missing sequence '
-        'named "lifecycle_stage_lifecycle_stage_id_seq"';
+        '"lifecycle_stage" and column "lifecycle_stage_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -32,13 +30,12 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings.use', 'use_id');
-    IF NOT FOUND THEN
-        RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings" table "use" and '
-        'column "use_id" is missing sequence named "use_use_id_seq"';
+    SELECT pg_get_serial_sequence('buildings.use', 'use_id') INTO seqname;
+    IF seqname IS NULL THEN
+        RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings" table '
+        '"use" and column "use_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -52,17 +49,16 @@ WHERE FALSE;
 
 DO $$
 DECLARE
+    seqname text;
     seqval integer;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings.buildings', 'building_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings.buildings', 'building_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings" table '
-        '"buildings" and column "building_id" is missing sequence named '
-        '"buildings_building_id_seq"';
+        '"buildings" and column "building_id" is missing a sequence';
     ELSE
-        SELECT nextval('buildings.buildings_building_id_seq') INTO seqval;
-        IF seqval < 999999 THEN
+        SELECT nextval(seqname) INTO seqval;
+        IF seqval < 1000000 THEN
             RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings" with table '
             '"buildings" and column "building_id" has a low sequence value';
         END IF;
@@ -99,7 +95,6 @@ BEGIN
     END IF;
 END;
 $$;
-
 
 DO $$
 BEGIN
@@ -163,20 +158,18 @@ $$;
 
 DO $$
 DECLARE
+    seqname text;
     seqval integer;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings.building_outlines', 'building_outline_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings.building_outlines', 'building_outline_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings" table '
-        '"building_outlines" and column "building_outline_id" is missing '
-        'sequence named "building_outlines_building_outline_id_seq"';
+        '"building_outlines" and column "building_outline_id" is missing a sequence';
     ELSE
-        SELECT nextval('buildings.building_outlines_building_outline_id_seq') INTO seqval;
-        IF seqval < 999999 THEN
+        SELECT nextval(seqname) INTO seqval;
+        IF seqval < 1000000 THEN
             RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings" with table '
-            '"building_outlines" and column "building_outline_id" has a low '
-            'sequence value';
+            '"building_outlines" and column "building_outline_id" has a low sequence value';
         END IF;
     END IF;
 END;
@@ -208,20 +201,18 @@ $$;
 
 DO $$
 DECLARE
+    seqname text;
     seqval integer;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings.building_name', 'building_name_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings.building_name', 'building_name_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings" table '
-        '"building_name" and column "building_name_id" is missing sequence '
-        'named "building_name_building_name_id_seq"';
+        '"building_name" and column "building_name_id" is missing a sequence';
     ELSE
-        SELECT nextval('buildings.building_name_building_name_id_seq') INTO seqval;
-        IF seqval < 999999 THEN
+        SELECT nextval(seqname) INTO seqval;
+        IF seqval < 1000000 THEN
             RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings" with table '
-            '"building_name" and column "building_name_id" has a low sequence '
-            'value';
+            '"building_name" and column "building_name_id" has a low sequence value';
         END IF;
     END IF;
 END;
@@ -268,20 +259,18 @@ $$;
 
 DO $$
 DECLARE
+    seqname text;
     seqval integer;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings.building_use', 'building_use_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings.building_use', 'building_use_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings" table '
-        '"building_use" and column "building_use_id" is missing sequence named '
-        '"building_use_building_use_id_seq"';
+        '"building_use" and column "building_use_id" is missing a sequence';
     ELSE
-        SELECT nextval('buildings.building_use_building_use_id_seq') INTO seqval;
-        IF seqval < 999999 THEN
+        SELECT nextval(seqname) INTO seqval;
+        IF seqval < 1000000 THEN
             RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings" with table '
-            '"building_use" and column "building_use_id" has a low sequence '
-            'value';
+            '"building_use" and column "building_use_id" has a low sequence value';
         END IF;
     END IF;
 END;
@@ -326,20 +315,18 @@ $$;
 
 DO $$
 DECLARE
+    seqname text;
     seqval integer;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings.lifecycle', 'lifecycle_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings.lifecycle', 'lifecycle_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings" table '
-        '"lifecycle" and column "lifecycle_id" is missing sequence named '
-        '"lifecycle_lifecycle_id_seq"';
+        '"lifecycle" and column "lifecycle_id" is missing a sequence';
     ELSE
-        SELECT nextval('buildings.lifecycle_lifecycle_id_seq') INTO seqval;
-        IF seqval < 999999 THEN
-            RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings" with '
-            'table "lifecycle" and column "lifecycle_id" has a low sequence '
-            'value';
+        SELECT nextval(seqname) INTO seqval;
+        IF seqval < 1000000 THEN
+            RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings" with table '
+            '"lifecycle" and column "building_use_id" has a low sequence value';
         END IF;
     END IF;
 END;

--- a/db/sql/verify/buildings_bulk_load/schema_and_tables.sql
+++ b/db/sql/verify/buildings_bulk_load/schema_and_tables.sql
@@ -12,14 +12,12 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_bulk_load.organisation', 'organisation_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_bulk_load.organisation', 'organisation_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_bulk_load" table '
-        '"organisation" and column "organisation_id" is missing sequence named '
-        '"organisation_organisation_id_seq"';
+        '"organisation" and column "organisation_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -32,14 +30,12 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_bulk_load.bulk_load_status', 'bulk_load_status_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_bulk_load.bulk_load_status', 'bulk_load_status_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_bulk_load" table '
-        '"bulk_load_status" and column "bulk_load_status_id" is missing '
-        'sequence named "bulk_load_status_bulk_load_status_id_seq"';
+        '"bulk_load_status" and column "bulk_load_status_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -52,14 +48,12 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_bulk_load.qa_status', 'qa_status_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_bulk_load.qa_status', 'qa_status_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_bulk_load" table '
-        '"qa_status" and column "qa_status_id" is missing sequence named '
-        '"qa_status_qa_status_id_seq"';
+        '"qa_status" and column "qa_status_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -90,14 +84,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_bulk_load.supplied_datasets', 'supplied_dataset_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_bulk_load.supplied_datasets', 'supplied_dataset_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_bulk_load" table '
-        '"supplied_datasets" and column "supplied_dataset_id" is missing '
-        'sequence named "supplied_datasets_supplied_dataset_id_seq"';
+        '"supplied_datasets" and column "supplied_dataset_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -143,20 +135,18 @@ $$;
 
 DO $$
 DECLARE
+    seqname text;
     seqval integer;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_bulk_load.supplied_outlines', 'supplied_outline_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_bulk_load.supplied_outlines', 'supplied_outline_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_bulk_load" table '
-        '"supplied_outlines" and column "supplied_outline_id" is missing '
-        'sequence named "supplied_outlines_supplied_outline_id_seq"';
+        '"supplied_outlines" and column "supplied_outline_id" is missing a sequence';
     ELSE
-    SELECT nextval('buildings_bulk_load.supplied_outlines_supplied_outline_id_seq') INTO seqval;
-        IF seqval < 999999 THEN
-            RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings_bulk_load" '
-            'with table "supplied_outlines" and column "supplied_outline_id" '
-            'has a low sequence value';
+        SELECT nextval(seqname) INTO seqval;
+        IF seqval < 1000000 THEN
+            RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings_bulk_load" with table '
+            '"supplied_outlines" and column "supplied_outline_id" has a low sequence value';
         END IF;
     END IF;
 END;
@@ -254,20 +244,18 @@ $$;
 
 DO $$
 DECLARE
+    seqname text;
     seqval integer;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_bulk_load.bulk_load_outlines', 'bulk_load_outline_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_bulk_load.bulk_load_outlines', 'bulk_load_outline_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_bulk_load" table '
-        '"bulk_load_outlines" and column "bulk_load_outline_id" is missing '
-        'sequence named "bulk_load_outlines_bulk_load_outline_id_seq"';
+        '"bulk_load_outlines" and column "bulk_load_outline_id" is missing a sequence';
     ELSE
-    SELECT nextval('buildings_bulk_load.bulk_load_outlines_bulk_load_outline_id_seq') INTO seqval;
-        IF seqval < 999999 THEN
-            RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings_bulk_load" '
-            'with table "bulk_load_outlines" and column "bulk_load_outline_id" '
-            'has a low sequence value';
+        SELECT nextval(seqname) INTO seqval;
+        IF seqval < 1000000 THEN
+            RAISE EXCEPTION 'LOW SEQUENCE VALUE: Schema "buildings_bulk_load" with table '
+            '"bulk_load_outlines" and column "bulk_load_outline_id" has a low sequence value';
         END IF;
     END IF;
 END;
@@ -359,14 +347,12 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_bulk_load.related_groups', 'related_group_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_bulk_load.related_groups', 'related_group_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_bulk_load" table '
-        '"related_groups" and column "related_group_id" is missing sequence '
-        'named "related_groups_related_group_id_seq"';
+        '"related_groups" and column "related_group_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -442,14 +428,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_bulk_load.related', 'related_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_bulk_load.related', 'related_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_bulk_load" table '
-        '"related" and column "related_id" is missing sequence named '
-        '"related_related_id_seq"';
+        '"related" and column "related_id" is missing a sequence';
     END IF;
 END;
 $$;

--- a/db/sql/verify/buildings_common/schema_and_tables.sql
+++ b/db/sql/verify/buildings_common/schema_and_tables.sql
@@ -12,14 +12,12 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_common.capture_method', 'capture_method_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_common.capture_method', 'capture_method_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_common" table '
-        '"capture_method" and column "capture_method_id" is missing sequence '
-        'named "capture_method_capture_method_id_seq"';
+        '"capture_method" and column "capture_method_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -33,14 +31,12 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_common.capture_source_group', 'capture_source_group_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_common.capture_source_group', 'capture_source_group_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_common" table '
-        '"capture_source_group" and column "capture_source_group_id" is '
-        'missing sequence named "capture_source_group_capture_source_group_id_seq"';
+        '"capture_source_group" and column "capture_source_group_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -69,17 +65,14 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_common.capture_source', 'capture_source_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_common.capture_source', 'capture_source_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_common" table '
-        '"capture_source" and column "capture_source_id" is missing sequence '
-        'named "capture_source_capture_source_id_seq"';
+        '"capture_source" and column "capture_source_id" is missing a sequence';
     END IF;
 END;
 $$;
-
 
 ROLLBACK;

--- a/db/sql/verify/buildings_reference/schema_and_tables.sql
+++ b/db/sql/verify/buildings_reference/schema_and_tables.sql
@@ -32,14 +32,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.suburb_locality', 'suburb_locality_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.suburb_locality', 'suburb_locality_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"suburb_locality" and column "suburb_locality_id" is missing sequence '
-        'named "suburb_locality_suburb_locality_id_seq"';
+        '"suburb_locality" and column "suburb_locality_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -68,14 +66,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.town_city', 'town_city_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.town_city', 'town_city_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"town_city" and column "town_city_id" is missing sequence named '
-        '"town_city_town_city_id_seq"';
+        '"town_city" and column "town_city_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -105,14 +101,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.territorial_authority', 'territorial_authority_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.territorial_authority', 'territorial_authority_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"territorial_authority" and column "territorial_authority_id" is '
-        'missing sequence named "territorial_authority_territorial_authority_id_seq"';
+        '"territorial_authority" and column "territorial_authority_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -150,14 +144,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.coastlines_and_islands', 'coastline_and_island_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.coastlines_and_islands', 'coastline_and_island_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"coastlines_and_islands" and column "coastline_and_island_id" is '
-        'missing sequence named "coastlines_and_islands_coastline_and_island_id_seq"';
+        '"coastlines_and_islands" and column "coastline_and_island_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -186,14 +178,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.lake_polygons', 'lake_polygon_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.lake_polygons', 'lake_polygon_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"lake_polygons" and column "lake_polygon_id" is missing sequence '
-        'named "lake_polygons_lake_polygon_id_seq"';
+        '"lake_polygons" and column "lake_polygon_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -222,14 +212,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.pond_polygons', 'pond_polygon_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.pond_polygons', 'pond_polygon_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"pond_polygons" and column "pond_polygon_id" is missing sequence '
-        'named "pond_polygons_pond_polygon_id_seq"';
+        '"pond_polygons" and column "pond_polygon_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -258,14 +246,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.swamp_polygons', 'swamp_polygon_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.swamp_polygons', 'swamp_polygon_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"swamp_polygons" and column "swamp_polygon_id" is missing sequence '
-        'named "swamp_polygons_swamp_polygon_id_seq"';
+        '"swamp_polygons" and column "swamp_polygon_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -294,14 +280,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.lagoon_polygons', 'lagoon_polygon_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.lagoon_polygons', 'lagoon_polygon_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"lagoon_polygons" and column "lagoon_polygon_id" is missing sequence '
-        'named "lagoon_polygons_lagoon_polygon_id_seq"';
+        '"lagoon_polygons" and column "lagoon_polygon_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -330,18 +314,15 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.canal_polygons', 'canal_polygon_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.canal_polygons', 'canal_polygon_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"canal_polygons" and column "canal_polygon_id" is missing sequence '
-        'named "canal_polygons_canal_polygon_id_seq"';
+        '"canal_polygons" and column "canal_polygon_id" is missing a sequence';
     END IF;
 END;
 $$;
-
 
 SELECT
       area_polygon_id
@@ -368,14 +349,12 @@ $$;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.capture_source_area', 'area_polygon_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.capture_source_area', 'area_polygon_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"capture_source_area" and column "area_polygon_id" is missing '
-        'sequence named "capture_source_area_area_polygon_id_seq"';
+        '"capture_source_area" and column "area_polygon_id" is missing a sequence';
     END IF;
 END;
 $$;
@@ -400,17 +379,14 @@ WHERE FALSE;
 
 DO $$
 DECLARE
-    seqval integer;
+    seqname text;
 BEGIN
-    PERFORM TRUE
-    FROM pg_get_serial_sequence('buildings_reference.reference_update_log', 'update_id');
-    IF NOT FOUND THEN
+    SELECT pg_get_serial_sequence('buildings_reference.reference_update_log', 'update_id') INTO seqname;
+    IF seqname IS NULL THEN
         RAISE EXCEPTION 'MISSING SEQUENCE: Schema "buildings_reference" table '
-        '"reference_update_log" and column "area_polygon_id" is missing '
-        'sequence named "reference_update_log_update_id_seq"';
+        '"reference_update_log" and column "update_id" is missing a sequence';
     END IF;
 END;
 $$;
-
 
 ROLLBACK;


### PR DESCRIPTION
Fixes: #307 
### Change Description:

Uses an `IS NULL` check rather than an `IS NOT FOUND` check to verify sequences.

### Notes for Testing:

- `sqitch verify`

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [x] All tests are passing in development environment
- [x] Reviewers assigned
- [x] Linked to main issue for ZenHub board
