### PR TITLE
Cluster & Analyze after bulk loads of new data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Added
 
 * Buildings toolbar and bulk load adding/editing functionality added to the alter relationships frame
 * Update the error status and comment in the QA layer if bulk load outline edited (edit-geometry and delete-outline only)
-* Added cluster and analyze to the bulk load tables
+* Added cluster and analyze to the bulk load tables, but on pkeys only.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Added
 
 * Buildings toolbar and bulk load adding/editing functionality added to the alter relationships frame
 * Update the error status and comment in the QA layer if bulk load outline edited (edit-geometry and delete-outline only)
-* Added reindex, cluster and analyze to the bulk load tables
+* Added cluster and analyze to the bulk load tables
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 
 * Buildings toolbar and bulk load adding/editing functionality added to the alter relationships frame
 * Update the error status and comment in the QA layer if bulk load outline edited (edit-geometry and delete-outline only)
+* Added reindex, cluster and analyze to the bulk load tables
 
 Changed
 -------

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -389,6 +389,8 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
             result = result.fetchall()[0][0]
             # if bulk loading completed without errors
             if result == 1:
+                # RCA the bulk load
+                self.db._execute(bulk_load_select.supplied_dataset_rca_db2)
                 QgsMapLayerRegistry.instance().layerWillBeRemoved.disconnect(self.layers_removed)
                 self.layer_registry.remove_layer(self.historic_layer)
                 QgsMapLayerRegistry.instance().layerWillBeRemoved.connect(self.layers_removed)

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -390,7 +390,8 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
             # if bulk loading completed without errors
             if result == 1:
                 # RCA the bulk load
-                result = self.db._execute(bulk_load_select.supplied_dataset_rca_db)
+                if commit_status:
+                    self.db._execute(bulk_load_select.supplied_dataset_rca_db)
                 QgsMapLayerRegistry.instance().layerWillBeRemoved.disconnect(self.layers_removed)
                 self.layer_registry.remove_layer(self.historic_layer)
                 QgsMapLayerRegistry.instance().layerWillBeRemoved.connect(self.layers_removed)

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -390,7 +390,7 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
             # if bulk loading completed without errors
             if result == 1:
                 # RCA the bulk load
-                self.db._execute(bulk_load_select.supplied_dataset_rca_db2)
+                result = self.db._execute(bulk_load_select.supplied_dataset_rca_db)
                 QgsMapLayerRegistry.instance().layerWillBeRemoved.disconnect(self.layers_removed)
                 self.layer_registry.remove_layer(self.historic_layer)
                 QgsMapLayerRegistry.instance().layerWillBeRemoved.connect(self.layers_removed)

--- a/buildings/sql/buildings_bulk_load_select_statements.py
+++ b/buildings/sql/buildings_bulk_load_select_statements.py
@@ -349,46 +349,45 @@ WHERE transfer_date is NULL;
 """
 
 supplied_dataset_rca_db = """
-CLUSTER buildings_bulk_load.added USING idx_added_qa_status_id;
+CLUSTER buildings_bulk_load.added USING added_pkey;
 ANALYZE buildings_bulk_load.added;
 
-CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_bulk_load_status_id;
-CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_capture_method_id;
-CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_capture_source_id;
-CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_supplied_dataset_id;
-CLUSTER buildings_bulk_load.bulk_load_outlines USING shx_bulk_load_outlines;
+CLUSTER buildings_bulk_load.bulk_load_outlines USING bulk_load_outlines_pkey;
 ANALYZE buildings_bulk_load.bulk_load_outlines;
 
-CLUSTER buildings_bulk_load.existing_subset_extracts USING idx_existing_subset_extracts_supplied_dataset_id;
-CLUSTER buildings_bulk_load.existing_subset_extracts USING shx_existing_subset_extracts;
+CLUSTER buildings_bulk_load.existing_subset_extracts USING existing_subset_extracts_pkey;
 ANALYZE buildings_bulk_load.existing_subset_extracts;
 
-CLUSTER buildings_bulk_load.matched USING idx_matched_building_outline_id;
-CLUSTER buildings_bulk_load.matched USING idx_matched_qa_status_id;
+CLUSTER buildings_bulk_load.matched USING matched_pkey;
 ANALYZE buildings_bulk_load.matched;
 
-CLUSTER buildings_bulk_load.related USING idx_related_building_outline_id;
-CLUSTER buildings_bulk_load.related USING idx_related_bulk_load_outline_id;
-CLUSTER buildings_bulk_load.related USING idx_related_qa_status_id;
-CLUSTER buildings_bulk_load.related USING idx_related_related_group_id;
+CLUSTER buildings_bulk_load.related USING related_pkey;
 ANALYZE buildings_bulk_load.related;
 
-CLUSTER buildings_bulk_load.removed USING idx_removed_qa_status_id;
+CLUSTER buildings_bulk_load.removed USING removed_pkey;
 ANALYZE buildings_bulk_load.removed;
 
-CLUSTER buildings_bulk_load.supplied_datasets USING idx_supplied_datasets_supplier_id;
+CLUSTER buildings_bulk_load.supplied_datasets USING supplied_datasets_pkey;
 ANALYZE buildings_bulk_load.supplied_datasets;
 
-CLUSTER buildings_bulk_load.supplied_outlines USING idx_supplied_outlines_supplied_dataset_id;
-CLUSTER buildings_bulk_load.supplied_outlines USING shx_supplied_outlines;
+CLUSTER buildings_bulk_load.supplied_outlines USING supplied_outlines_pkey;
 ANALYZE buildings_bulk_load.supplied_outlines;
 
-CLUSTER buildings_bulk_load.transferred USING idx_transferred_new_building_outline_id;
+CLUSTER buildings_bulk_load.transferred USING transferred_pkey;
 ANALYZE buildings_bulk_load.transferred;
 
+CLUSTER buildings_bulk_load.related_groups USING related_groups_pkey;
 ANALYZE buildings_bulk_load.related_groups;
+
+CLUSTER buildings_bulk_load.qa_status USING qa_status_pkey;
 ANALYZE buildings_bulk_load.qa_status;
+
+CLUSTER buildings_bulk_load.organisation USING organisation_pkey;
 ANALYZE buildings_bulk_load.organisation;
+
+CLUSTER buildings_bulk_load.deletion_description USING deletion_description_pkey;
 ANALYZE buildings_bulk_load.deletion_description;
+
+CLUSTER buildings_bulk_load.bulk_load_status USING bulk_load_status_pkey;
 ANALYZE buildings_bulk_load.bulk_load_status;
 """

--- a/buildings/sql/buildings_bulk_load_select_statements.py
+++ b/buildings/sql/buildings_bulk_load_select_statements.py
@@ -401,6 +401,3 @@ ANALYZE buildings_bulk_load.organisation;
 ANALYZE buildings_bulk_load.deletion_description;
 ANALYZE buildings_bulk_load.bulk_load_status;
 """
-supplied_dataset_rca_db2 = """
-REINDEX INDEX buildings_bulk_load.shx_bulk_load_outlines;
-"""

--- a/buildings/sql/buildings_bulk_load_select_statements.py
+++ b/buildings/sql/buildings_bulk_load_select_statements.py
@@ -349,11 +349,9 @@ WHERE transfer_date is NULL;
 """
 
 supplied_dataset_rca_db = """
-REINDEX TABLE buildings_bulk_load.added;
 CLUSTER buildings_bulk_load.added USING idx_added_qa_status_id;
 ANALYZE buildings_bulk_load.added;
 
-REINDEX TABLE buildings_bulk_load.bulk_load_outlines;
 CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_bulk_load_status_id;
 CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_capture_method_id;
 CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_capture_source_id;
@@ -361,37 +359,30 @@ CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_supp
 CLUSTER buildings_bulk_load.bulk_load_outlines USING shx_bulk_load_outlines;
 ANALYZE buildings_bulk_load.bulk_load_outlines;
 
-REINDEX TABLE buildings_bulk_load.existing_subset_extracts;
 CLUSTER buildings_bulk_load.existing_subset_extracts USING idx_existing_subset_extracts_supplied_dataset_id;
 CLUSTER buildings_bulk_load.existing_subset_extracts USING shx_existing_subset_extracts;
 ANALYZE buildings_bulk_load.existing_subset_extracts;
 
-REINDEX TABLE buildings_bulk_load.matched;
 CLUSTER buildings_bulk_load.matched USING idx_matched_building_outline_id;
 CLUSTER buildings_bulk_load.matched USING idx_matched_qa_status_id;
 ANALYZE buildings_bulk_load.matched;
 
-REINDEX TABLE buildings_bulk_load.related;
 CLUSTER buildings_bulk_load.related USING idx_related_building_outline_id;
 CLUSTER buildings_bulk_load.related USING idx_related_bulk_load_outline_id;
 CLUSTER buildings_bulk_load.related USING idx_related_qa_status_id;
 CLUSTER buildings_bulk_load.related USING idx_related_related_group_id;
 ANALYZE buildings_bulk_load.related;
 
-REINDEX TABLE buildings_bulk_load.removed;
 CLUSTER buildings_bulk_load.removed USING idx_removed_qa_status_id;
 ANALYZE buildings_bulk_load.removed;
 
-REINDEX TABLE buildings_bulk_load.supplied_datasets;
 CLUSTER buildings_bulk_load.supplied_datasets USING idx_supplied_datasets_supplier_id;
 ANALYZE buildings_bulk_load.supplied_datasets;
 
-REINDEX TABLE buildings_bulk_load.supplied_outlines;
 CLUSTER buildings_bulk_load.supplied_outlines USING idx_supplied_outlines_supplied_dataset_id;
 CLUSTER buildings_bulk_load.supplied_outlines USING shx_supplied_outlines;
 ANALYZE buildings_bulk_load.supplied_outlines;
 
-REINDEX TABLE buildings_bulk_load.transferred;
 CLUSTER buildings_bulk_load.transferred USING idx_transferred_new_building_outline_id;
 ANALYZE buildings_bulk_load.transferred;
 

--- a/buildings/sql/buildings_bulk_load_select_statements.py
+++ b/buildings/sql/buildings_bulk_load_select_statements.py
@@ -58,6 +58,7 @@ Bulk Load Outlines Select Statements:
   - supplied_dataset_processed_date_by_dataset_id (supplied_dataset_id)
   - supplied_dataset_processed_date_is_null
   - supplied_dataset_transfer_date_is_null
+  - supplied_dataset_rca_db
 
 -------------------------------------------------------------------
 """
@@ -345,4 +346,61 @@ supplied_dataset_transfer_date_is_null = """
 SELECT supplied_dataset_id
 FROM buildings_bulk_load.supplied_datasets
 WHERE transfer_date is NULL;
+"""
+
+supplied_dataset_rca_db = """
+REINDEX TABLE buildings_bulk_load.added;
+CLUSTER buildings_bulk_load.added USING idx_added_qa_status_id;
+ANALYZE buildings_bulk_load.added;
+
+REINDEX TABLE buildings_bulk_load.bulk_load_outlines;
+CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_bulk_load_status_id;
+CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_capture_method_id;
+CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_capture_source_id;
+CLUSTER buildings_bulk_load.bulk_load_outlines USING idx_bulk_load_outlines_supplied_dataset_id;
+CLUSTER buildings_bulk_load.bulk_load_outlines USING shx_bulk_load_outlines;
+ANALYZE buildings_bulk_load.bulk_load_outlines;
+
+REINDEX TABLE buildings_bulk_load.existing_subset_extracts;
+CLUSTER buildings_bulk_load.existing_subset_extracts USING idx_existing_subset_extracts_supplied_dataset_id;
+CLUSTER buildings_bulk_load.existing_subset_extracts USING shx_existing_subset_extracts;
+ANALYZE buildings_bulk_load.existing_subset_extracts;
+
+REINDEX TABLE buildings_bulk_load.matched;
+CLUSTER buildings_bulk_load.matched USING idx_matched_building_outline_id;
+CLUSTER buildings_bulk_load.matched USING idx_matched_qa_status_id;
+ANALYZE buildings_bulk_load.matched;
+
+REINDEX TABLE buildings_bulk_load.related;
+CLUSTER buildings_bulk_load.related USING idx_related_building_outline_id;
+CLUSTER buildings_bulk_load.related USING idx_related_bulk_load_outline_id;
+CLUSTER buildings_bulk_load.related USING idx_related_qa_status_id;
+CLUSTER buildings_bulk_load.related USING idx_related_related_group_id;
+ANALYZE buildings_bulk_load.related;
+
+REINDEX TABLE buildings_bulk_load.removed;
+CLUSTER buildings_bulk_load.removed USING idx_removed_qa_status_id;
+ANALYZE buildings_bulk_load.removed;
+
+REINDEX TABLE buildings_bulk_load.supplied_datasets;
+CLUSTER buildings_bulk_load.supplied_datasets USING idx_supplied_datasets_supplier_id;
+ANALYZE buildings_bulk_load.supplied_datasets;
+
+REINDEX TABLE buildings_bulk_load.supplied_outlines;
+CLUSTER buildings_bulk_load.supplied_outlines USING idx_supplied_outlines_supplied_dataset_id;
+CLUSTER buildings_bulk_load.supplied_outlines USING shx_supplied_outlines;
+ANALYZE buildings_bulk_load.supplied_outlines;
+
+REINDEX TABLE buildings_bulk_load.transferred;
+CLUSTER buildings_bulk_load.transferred USING idx_transferred_new_building_outline_id;
+ANALYZE buildings_bulk_load.transferred;
+
+ANALYZE buildings_bulk_load.related_groups;
+ANALYZE buildings_bulk_load.qa_status;
+ANALYZE buildings_bulk_load.organisation;
+ANALYZE buildings_bulk_load.deletion_description;
+ANALYZE buildings_bulk_load.bulk_load_status;
+"""
+supplied_dataset_rca_db2 = """
+REINDEX INDEX buildings_bulk_load.shx_bulk_load_outlines;
 """


### PR DESCRIPTION
Fixes: #305   and related to #249 

After we bulk load outlines, the build load tables are in need of Reindexing, Clustering and Analyzing to allow LIQA scripts to run efficiently.

### Change Description:
buildings/gui/bulk_load_frame:
 - After bulk load completed without errors, run RCA on the bulk load tables.

buildings/sql/buildings_bulk_load_select_statements:
- RCA statements for execution added


### Notes for Testing:
These changes cannot be tested using the test_processes_bulk_load_outlines in script assistant.
You must manually bulk load some data, and it will work.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
