### PR TITLE
Fix failing travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jobs:
     env: BUILD=docs
     language: python
     python: 2.7
+    dist: trusty
     before_install: []
     install:
     - pip install Sphinx sphinx_rtd_theme
@@ -190,6 +191,7 @@ jobs:
       PYTHON_EXECUTABLE=python PIP_EXECUTABLE=pip
     language: python
     python: 2.7
+    dist: trusty
     services: docker
     before_install:
     - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
     env: BUILD=db PGSQL=9.4 PGIS=2.3 PGPORT=5432
     language: python
     python: 2.7
+    dist: trusty
     addons:
       postgresql: 9.4
       apt:
@@ -48,6 +49,7 @@ jobs:
     env: BUILD=db PGSQL=9.5 PGIS=2.3 PGPORT=5432
     language: python
     python: 2.7
+    dist: trusty
     addons:
       postgresql: 9.5
       apt:
@@ -75,6 +77,7 @@ jobs:
     env: BUILD=db PGSQL=9.5 PGIS=2.4 PGPORT=5432
     language: python
     python: 2.7
+    dist: trusty
     addons:
       postgresql: 9.5
       apt:
@@ -102,6 +105,7 @@ jobs:
     env: BUILD=db PGSQL=9.6 PGIS=2.3 PGPORT=5432
     language: python
     python: 2.7
+    dist: trusty
     addons:
       postgresql: 9.6
       apt:
@@ -129,6 +133,7 @@ jobs:
     env: BUILD=db PGSQL=9.6 PGIS=2.4 PGPORT=5432
     language: python
     python: 2.7
+    dist: trusty
     addons:
       postgresql: 9.6
       apt:
@@ -156,6 +161,7 @@ jobs:
     env: BUILD=db PGSQL=10 PGIS=2.4 PGPORT=5433
     language: python
     python: 2.7
+    dist: trusty
     addons:
       postgresql: 10
       apt:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Fixed
 * Warning messages for when multiple buildings are added at once
 * Users can correctly remove added outlines or revert changes when adding multiple outlines with 'add outline' functionality.
 * Remove functionality repopulate_error_attribute_table to LIQA plugin.
+* Add dist:Trusty in travis-ci config so travis-ci can run in the right build.
 
 1.4.0
 ==========


### PR DESCRIPTION
Fixes: #321 

### Change Description:

Add `dist` setting in travis-ci config so the distribution for builds stays as `Trusty`.

### Notes for Testing:

See travis-ci result

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [x] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
