### PR TITLE
Include the name variable inserts and updates for the reference

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Change Log
 
 All notable changes to this project will be documented in this file.
 
+Unreleased
+==========
+
+Fixed
+-----
+
+* Include name in the update or insert functions for reference data (hut, shelter, bivouac and protected area).
+
+
 2.0.0
 ==========
 02-08-2019

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Fixed
 -----
 
 * Include name in the update or insert functions for reference data (hut, shelter, bivouac and protected area).
+* Fix sqitch deployment to 'sqitch deploy --verify'
 
 
 2.0.0

--- a/buildings/reference_data/topo50.py
+++ b/buildings/reference_data/topo50.py
@@ -94,10 +94,19 @@ def update_topo50(kx_api_key, dataset):
                 result = db.execute_return(reference_select.select_point_id_by_external_id.format(column_name), (feature.attribute(external_id),))
             result = result.fetchone()
             if result is None:
-                sql = 'SELECT buildings_reference.{}_insert(%s, %s)'.format(dataset)
-                db.execute(sql, (feature.attribute(external_id), feature.geometry().exportToWkt()))
+                sql = 'SELECT buildings_reference.{}_insert(%s, %s, %s)'.format(dataset)
+                db.execute(sql, (feature.attribute(external_id), correct_name_format(feature['name']), feature.geometry().exportToWkt()))
 
         elif feature.attribute('__change__') == 'UPDATE':
-            sql = 'SELECT buildings_reference.{}_update_shape_by_external_id(%s, %s)'.format(dataset)
-            db.execute(sql, (feature.attribute(external_id), feature.geometry().exportToWkt()))
+            sql = 'SELECT buildings_reference.{}_update_by_external_id(%s, %s, %s)'.format(dataset)
+            db.execute(sql, (feature.attribute(external_id), correct_name_format(feature['name']), feature.geometry().exportToWkt()))
     return 'updated'
+
+
+def correct_name_format(name):
+    if name:
+        if "'" in name:
+            name = "{}".format(name.replace("'", "''"))
+    else:
+        name = ''
+    return str(name)

--- a/db/scripts/nz-buildings-load.in
+++ b/db/scripts/nz-buildings-load.in
@@ -111,8 +111,7 @@ fi
 
 # Deploy buildings using sqitch and then verify deployment
 cd ${SCRIPTSDIR}/sql
-sqitch deploy
-sqitch verify
+sqitch deploy --verify
 cd -
 
 # Execute files that create test data - test data remains in database

--- a/db/sql/deploy/buildings_reference/functions/change_reference_name_col_insert.sql
+++ b/db/sql/deploy/buildings_reference/functions/change_reference_name_col_insert.sql
@@ -1,0 +1,193 @@
+-- Deploy nz-buildings:buildings_reference/functions/change_reference_name_col_insert to pg
+
+BEGIN;
+
+-- Bivouac
+
+DROP FUNCTION IF EXISTS buildings_reference.bivouac_points_insert(integer, varchar);
+
+DROP FUNCTION IF EXISTS buildings_reference.bivouac_points_update_shape_by_external_id(integer, varchar);
+
+
+-- bivouac_points_insert
+    -- params: integer external_bivouac_points_id, varchar name, varchar geometry
+    -- return: integer bivouac_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.bivouac_points_insert(integer, varchar, varchar)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings_reference.bivouac_points (external_bivouac_points_id, name, shape)
+    VALUES ($1, $2, ST_SetSRID(ST_GeometryFromText($3), 2193))
+    RETURNING bivouac_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.bivouac_points_insert(integer, varchar, varchar) IS
+'Insert new entry into bivouac_points table';
+
+
+-- bivouac_points_update_by_external_id
+    -- params: integer external_bivouac_points_id, varchar name, varchar geometry
+    -- return: integer bivouac_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.bivouac_points_update_by_external_id(integer, varchar, varchar)
+RETURNS integer AS
+$$
+
+    UPDATE buildings_reference.bivouac_points
+    SET name = $2,
+        shape = ST_SetSRID(ST_GeometryFromText($3), 2193)
+    WHERE external_bivouac_points_id = $1
+    RETURNING bivouac_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.bivouac_points_update_by_external_id(integer, varchar, varchar) IS
+'Update name and geometry of bivouacs based on external_bivouac_points_id';
+
+
+-- Hut
+
+DROP FUNCTION IF EXISTS buildings_reference.hut_points_insert(integer, varchar);
+
+DROP FUNCTION IF EXISTS buildings_reference.hut_points_update_shape_by_external_id(integer, varchar);
+
+
+-- hut_points_insert
+    -- params: integer external_hut_points_id, varchar name, varchar geometry
+    -- return: integer hut_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.hut_points_insert(integer, varchar, varchar)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings_reference.hut_points (external_hut_points_id, name, shape)
+    VALUES ($1, $2, ST_SetSRID(ST_GeometryFromText($3), 2193))
+    RETURNING hut_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.hut_points_insert(integer, varchar, varchar) IS
+'Insert new entry into hut_points table';
+
+
+-- hut_points_update_by_external_id
+    -- params: integer external_hut_points_id, varchar name, varchar geometry
+    -- return: integer hut_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.hut_points_update_by_external_id(integer, varchar, varchar)
+RETURNS integer AS
+$$
+
+    UPDATE buildings_reference.hut_points
+    SET name = $2,
+        shape = ST_SetSRID(ST_GeometryFromText($3), 2193)
+    WHERE external_hut_points_id = $1
+    RETURNING hut_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.hut_points_update_by_external_id(integer, varchar, varchar) IS
+'Update name and geometry of huts based on external_hut_points_id';
+
+
+-- Protected Area
+
+DROP FUNCTION IF EXISTS buildings_reference.protected_areas_polygons_insert(integer, varchar);
+
+DROP FUNCTION IF EXISTS buildings_reference.protected_areas_polygons_update_shape_by_external_id(integer, varchar);
+
+
+-- protected_areas_polygons_insert
+    -- params: integer external_protected_areas_polygon_id, varchar name, varchar geometry
+    -- return: integer protected_areas_polygon_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.protected_areas_polygons_insert(integer, varchar, varchar)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings_reference.protected_areas_polygons (external_protected_areas_polygon_id, name, shape)
+    VALUES ($1, $2, ST_SetSRID(ST_GeometryFromText($3), 2193))
+    RETURNING protected_areas_polygon_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.protected_areas_polygons_insert(integer, varchar, varchar) IS
+'Insert new entry into protected_areas_polygons table';
+
+
+-- protected_areas_polygons_update_by_external_id
+    -- params: integer external_protected_areas_polygon_id, varchar name, varchar geometry
+    -- return: integer protected_areas_polygon_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.protected_areas_polygons_update_by_external_id(integer, varchar, varchar)
+RETURNS integer AS
+$$
+
+    UPDATE buildings_reference.protected_areas_polygons
+    SET name = $2,
+        shape = ST_SetSRID(ST_GeometryFromText($3), 2193)
+    WHERE external_protected_areas_polygon_id = $1
+    RETURNING protected_areas_polygon_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.protected_areas_polygons_update_by_external_id(integer, varchar, varchar) IS
+'Update name and geometry of protected areas based on external_protected_areas_polygon_id';
+
+
+-- Shelter
+
+DROP FUNCTION IF EXISTS buildings_reference.shelter_points_insert(integer, varchar);
+
+DROP FUNCTION IF EXISTS buildings_reference.shelter_points_update_shape_by_external_id(integer, varchar);
+
+
+-- shelter_points_insert
+    -- params: integer external_shelter_points_id, varchar name, varchar geometry
+    -- return: integer shelter_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.shelter_points_insert(integer, varchar, varchar)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings_reference.shelter_points (external_shelter_points_id, name, shape)
+    VALUES ($1, $2, ST_SetSRID(ST_GeometryFromText($3), 2193))
+    RETURNING shelter_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.shelter_points_insert(integer, varchar, varchar) IS
+'Insert new entry into shelter_points table';
+
+
+-- shelter_points_update_by_external_id
+    -- params: integer external_shelter_points_id, varchar name, varchar geometry
+    -- return: integer shelter_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.shelter_points_update_by_external_id(integer, varchar, varchar)
+RETURNS integer AS
+$$
+
+    UPDATE buildings_reference.shelter_points
+    SET name = $2,
+        shape = ST_SetSRID(ST_GeometryFromText($3), 2193)
+    WHERE external_shelter_points_id = $1
+    RETURNING shelter_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.shelter_points_update_by_external_id(integer, varchar, varchar) IS
+'Update name and geometry of shelters based on external_shelter_points_id';
+
+
+COMMIT;

--- a/db/sql/revert/buildings_reference/functions/change_reference_name_col_insert.sql
+++ b/db/sql/revert/buildings_reference/functions/change_reference_name_col_insert.sql
@@ -1,0 +1,189 @@
+-- Revert nz-buildings:buildings_reference/functions/change_reference_name_col_insert from pg
+
+BEGIN;
+
+-- Bivouac
+
+DROP FUNCTION IF EXISTS buildings_reference.bivouac_points_insert(integer, varchar, varchar);
+
+DROP FUNCTION IF EXISTS buildings_reference.bivouac_points_update_by_external_id(integer, varchar, varchar);
+
+
+-- bivouac_points_insert
+    -- params: integer external_bivouac_points_id, varchar geometry
+    -- return: integer bivouac_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.bivouac_points_insert(integer, varchar)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings_reference.bivouac_points (external_bivouac_points_id, shape)
+    VALUES ($1, ST_SetSRID(ST_GeometryFromText($2), 2193))
+    RETURNING bivouac_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.bivouac_points_insert(integer, varchar) IS
+'Insert new entry into bivouac_points table';
+
+
+-- bivouac_points_update_shape_by_external_id
+    -- params: integer external_bivouac_points_id, varchar geometry
+    -- return: integer bivouac_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.bivouac_points_update_shape_by_external_id(integer, varchar)
+RETURNS integer AS
+$$
+
+    UPDATE buildings_reference.bivouac_points
+    SET shape = ST_SetSRID(ST_GeometryFromText($2), 2193)
+    WHERE external_bivouac_points_id = $1
+    RETURNING bivouac_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.bivouac_points_update_shape_by_external_id(integer, varchar) IS
+'Update geometry of bivouacs based on external_bivouac_points_id';
+
+
+-- Hut
+
+DROP FUNCTION IF EXISTS buildings_reference.hut_points_insert(integer, varchar, varchar);
+
+DROP FUNCTION IF EXISTS buildings_reference.hut_points_update_by_external_id(integer, varchar, varchar);
+
+
+-- hut_points_insert
+    -- params: integer external_hut_points_id, varchar geometry
+    -- return: integer hut_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.hut_points_insert(integer, varchar)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings_reference.hut_points (external_hut_points_id, shape)
+    VALUES ($1, ST_SetSRID(ST_GeometryFromText($2), 2193))
+    RETURNING hut_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.hut_points_insert(integer, varchar) IS
+'Insert new entry into hut_points table';
+
+
+-- hut_points_update_shape_by_external_id
+    -- params: integer external_hut_points_id, varchar geometry
+    -- return: integer hut_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.hut_points_update_shape_by_external_id(integer, varchar)
+RETURNS integer AS
+$$
+
+    UPDATE buildings_reference.hut_points
+    SET shape = ST_SetSRID(ST_GeometryFromText($2), 2193)
+    WHERE external_hut_points_id = $1
+    RETURNING hut_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.hut_points_update_shape_by_external_id(integer, varchar) IS
+'Update geometry of huts based on external_hut_points_id';
+
+
+-- Protected Area
+
+DROP FUNCTION IF EXISTS buildings_reference.protected_areas_polygons_insert(integer, varchar, varchar);
+
+DROP FUNCTION IF EXISTS buildings_reference.protected_areas_polygons_update_by_external_id(integer, varchar, varchar);
+
+
+-- protected_areas_polygons_insert
+    -- params: integer external_protected_areas_polygon_id, varchar geometry
+    -- return: integer protected_areas_polygon_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.protected_areas_polygons_insert(integer, varchar)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings_reference.protected_areas_polygons (external_protected_areas_polygon_id, shape)
+    VALUES ($1, ST_SetSRID(ST_GeometryFromText($2), 2193))
+    RETURNING protected_areas_polygon_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.protected_areas_polygons_insert(integer, varchar) IS
+'Insert new entry into protected_areas_polygons table';
+
+
+-- protected_areas_polygons_update_shape_by_external_id
+    -- params: integer external_protected_areas_polygon_id, varchar geometry
+    -- return: integer protected_areas_polygon_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.protected_areas_polygons_update_shape_by_external_id(integer, varchar)
+RETURNS integer AS
+$$
+
+    UPDATE buildings_reference.protected_areas_polygons
+    SET shape = ST_SetSRID(ST_GeometryFromText($2), 2193)
+    WHERE external_protected_areas_polygon_id = $1
+    RETURNING protected_areas_polygon_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.protected_areas_polygons_update_shape_by_external_id(integer, varchar) IS
+'Update geometry of protected areas based on external_protected_areas_polygon_id';
+
+
+-- Shelter
+
+DROP FUNCTION IF EXISTS buildings_reference.shelter_points_insert(integer, varchar, varchar);
+
+DROP FUNCTION IF EXISTS buildings_reference.shelter_points_update_by_external_id(integer, varchar, varchar);
+
+
+-- shelter_points_insert
+    -- params: integer external_shelter_points_id, varchar geometry
+    -- return: integer shelter_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.shelter_points_insert(integer, varchar)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings_reference.shelter_points (external_shelter_points_id, shape)
+    VALUES ($1, ST_SetSRID(ST_GeometryFromText($2), 2193))
+    RETURNING shelter_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.shelter_points_insert(integer, varchar) IS
+'Insert new entry into shelter_points table';
+
+
+-- shelter_points_update_shape_by_external_id
+    -- params: integer external_shelter_points_id, varchar geometry
+    -- return: integer shelter_points_id
+
+CREATE OR REPLACE FUNCTION buildings_reference.shelter_points_update_shape_by_external_id(integer, varchar)
+RETURNS integer AS
+$$
+
+    UPDATE buildings_reference.shelter_points
+    SET shape = ST_SetSRID(ST_GeometryFromText($2), 2193)
+    WHERE external_shelter_points_id = $1
+    RETURNING shelter_points_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings_reference.shelter_points_update_shape_by_external_id(integer, varchar) IS
+'Update geometry of shelters based on external_shelter_points_id';
+
+
+COMMIT;

--- a/db/sql/sqitch.plan
+++ b/db/sql/sqitch.plan
@@ -55,3 +55,6 @@ buildings_reference/functions/hut_points 2019-06-20T03:06:41Z Jan Ducnuigeen <jd
 buildings_reference/functions/shelter_points 2019-06-20T03:37:13Z Jan Ducnuigeen <jducnuigeen@linz.govt.nz> # Add function for interacting with shelter_points
 buildings_reference/functions/bivouac_points 2019-06-20T04:04:21Z Jan Ducnuigeen <jducnuigeen@linz.govt.nz> # Add function for interacting with bivouac_points
 buildings_reference/functions/protected_area_polygons 2019-06-20T19:43:21Z Jan Ducnuigeen <jducnuigeen@linz.govt.nz> # Add function for interacting with protected area polygons
+@v2.0.0-dev1 2019-08-22T03:43:17Z Chen Yingting <ychen@linz.govt.nz> # Tag v2.0.0-dev1
+
+buildings_reference/functions/change_reference_name_col_insert 2019-08-30T01:40:37Z Chen Yingting <ychen@linz.govt.nz> # Alter the functions to allow updates or inserts on reference name column

--- a/db/sql/verify/buildings_reference/functions/change_reference_name_col_insert.sql
+++ b/db/sql/verify/buildings_reference/functions/change_reference_name_col_insert.sql
@@ -1,0 +1,25 @@
+-- Verify nz-buildings:buildings_reference/functions/change_reference_name_col_insert on pg
+
+BEGIN;
+
+SELECT has_function_privilege('buildings_reference.bivouac_points_insert(integer, varchar, varchar)', 'execute');
+
+SELECT has_function_privilege('buildings_reference.bivouac_points_update_by_external_id(integer, varchar, varchar)', 'execute');
+
+
+SELECT has_function_privilege('buildings_reference.hut_points_insert(integer, varchar, varchar)', 'execute');
+
+SELECT has_function_privilege('buildings_reference.hut_points_update_by_external_id(integer, varchar, varchar)', 'execute');
+
+
+SELECT has_function_privilege('buildings_reference.protected_areas_polygons_insert(integer, varchar, varchar)', 'execute');
+
+SELECT has_function_privilege('buildings_reference.protected_areas_polygons_update_by_external_id(integer, varchar, varchar)', 'execute');
+
+
+SELECT has_function_privilege('buildings_reference.shelter_points_insert(integer, varchar, varchar)', 'execute');
+
+SELECT has_function_privilege('buildings_reference.shelter_points_update_by_external_id(integer, varchar, varchar)', 'execute');
+
+
+ROLLBACK;

--- a/db/tests/buildings_reference.pg
+++ b/db/tests/buildings_reference.pg
@@ -128,19 +128,19 @@ SELECT has_function('buildings_reference', 'swamp_polygons_insert', 'Should have
 SELECT has_function('buildings_reference', 'reference_update_log_insert_log', 'Should have function reference_update_log_insert_log in buildings_reference.');
 
 SELECT has_function('buildings_reference', 'hut_points_delete_by_external_id', 'Should have function hut_points_delete_by_external_id in buildings_reference.');
-SELECT has_function('buildings_reference', 'hut_points_update_shape_by_external_id', 'Should have function hut_points_update_shape_by_external_id in buildings_reference.');
+SELECT has_function('buildings_reference', 'hut_points_update_by_external_id', 'Should have function hut_points_update_by_external_id in buildings_reference.');
 SELECT has_function('buildings_reference', 'hut_points_insert', 'Should have function hut_points_insert in buildings_reference.');
 
 SELECT has_function('buildings_reference', 'shelter_points_delete_by_external_id', 'Should have function shelter_points_delete_by_external_id in buildings_reference.');
-SELECT has_function('buildings_reference', 'shelter_points_update_shape_by_external_id', 'Should have function shelter_points_update_shape_by_external_id in buildings_reference.');
+SELECT has_function('buildings_reference', 'shelter_points_update_by_external_id', 'Should have function shelter_points_update_by_external_id in buildings_reference.');
 SELECT has_function('buildings_reference', 'shelter_points_insert', 'Should have function shelter_points_insert in buildings_reference.');
 
 SELECT has_function('buildings_reference', 'bivouac_points_delete_by_external_id', 'Should have function bivouac_points_delete_by_external_id in buildings_reference.');
-SELECT has_function('buildings_reference', 'bivouac_points_update_shape_by_external_id', 'Should have function bivouac_points_update_shape_by_external_id in buildings_reference.');
+SELECT has_function('buildings_reference', 'bivouac_points_update_by_external_id', 'Should have function bivouac_points_update_by_external_id in buildings_reference.');
 SELECT has_function('buildings_reference', 'bivouac_points_insert', 'Should have function bivouac_points_insert in buildings_reference.');
 
 SELECT has_function('buildings_reference', 'protected_areas_polygons_delete_by_external_id', 'Should have function protected_areas_polygons_delete_by_external_id in buildings_reference.');
-SELECT has_function('buildings_reference', 'protected_areas_polygons_update_shape_by_external_id', 'Should have function protected_areas_polygons_update_shape_by_external_id in buildings_reference.');
+SELECT has_function('buildings_reference', 'protected_areas_polygons_update_by_external_id', 'Should have function protected_areas_polygons_update_by_external_id in buildings_reference.');
 SELECT has_function('buildings_reference', 'protected_areas_polygons_insert', 'Should have function protected_areas_polygons_insert in buildings_reference.');
 
 -- Finish pgTAP testing

--- a/install.py
+++ b/install.py
@@ -89,7 +89,8 @@ SQL_SCRIPTS = [
     os.path.join("sql", "deploy", "buildings_reference", "functions", "bivouac_points.sql"),
     os.path.join("sql", "deploy", "buildings_reference", "functions", "hut_points.sql"),
     os.path.join("sql", "deploy", "buildings_reference", "functions", "protected_area_polygons.sql"),
-    os.path.join("sql", "deploy", "buildings_reference", "functions", "shelter_points.sql")
+    os.path.join("sql", "deploy", "buildings_reference", "functions", "shelter_points.sql"),
+    os.path.join("sql", "deploy", "buildings_reference", "functions", "change_reference_name_col_insert.sql")
 
 ]
 


### PR DESCRIPTION
Fixes: #323 

### Change Description:

`Sqitch rework` on hut_points, shelter_points, bivouac_points and proctected_area_polygons so the name variable of those reference can be updated.

Plugin function `Correct_name_format` is used because name string like `Poor Pete's Hut`(it's a real hut) will raise database error when running sql query. 

### Notes for Testing:

Use the plugin to update reference. See if the name variable is added

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [x] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
