### PR TITLE
Add pre-commit to lint git commit messages to match conventional commits spec

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,18 @@
+# Configuration file for gitlint, used via pre-commit
+# Configuration docs: http://jorisroovers.github.io/gitlint/configuration/
+# Default rules: https://github.com/jorisroovers/gitlint/blob/master/docs/rules.md
+
+[general]
+# Ignore certain rules, you can reference them by their id or by their full name
+ignore=body-is-missing, body-max-line-length
+
+# Enable community contributed rule for conventional commits
+contrib=contrib-title-conventional-commits
+
+[title-max-length]
+line-length=72
+
+[contrib-title-conventional-commits]
+# Specify allowed commit types. For details see: https://www.conventionalcommits.org/
+types = build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Configuration file for pre-commit (https://pre-commit.com/)
+
+repos:
+-  repo: https://github.com/jorisroovers/gitlint
+   rev: v0.12.0
+   hooks:
+   -  id: gitlint
+      stages: [commit-msg]
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,25 @@
 stages:
+  - linter
   - docs
   - database
   - plugin
 
 jobs:
   include:
+    - stage: linter
+      env: BUILD=linter
+      language: python
+      python: 3.6
+      dist: trusty
+      install:
+        - python -m pip install --upgrade pip
+        - pip install -r requirements-dev.txt
+      before_script:
+        # Travis-CI does not include master in the build by default
+        - git fetch origin refs/heads/master:refs/heads/master
+      script:
+        - gitlint --commits master..
+
     - stage: docs
       env: BUILD=docs
       language: python

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 Unreleased
 ==========
 
+Added
+-----
+
+* Ensure git commit messages conform to the conventional commits spec
+
 Changed
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -145,11 +145,33 @@ The plugin can be installed in the local plugin folder from this repository.
 Development
 -----------
 
+Clone, then create and activate a virtual environment.
+
+.. code-block:: shell
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+
+``python3`` must be 3.6+.
+
+Upgrade ``pip`` and install the required dependencies.
+
+.. code-block:: shell
+
+    pip install --upgrade pip
+    pip install -r requirements-dev.txt
+I
+Install ``commit-msg`` git hook.
+
+.. code-block:: shell
+
+    pre-commit install --hook-type commit-msg
+
 Creating a symlink from the repo to the local QGIS plugin directory makes it easy to evaluate changes to QGIS plugin code.
 
-.. code-block:: 
+.. code-block:: shell
 
-    ln -s $DEV/nz-buildings/buildings $HOME/.qgis2/python/plugins/buildings
+    ln -s $DEV/nz-buildings/buildings $HOME/.local/share/QGIS/QGIS3/profiles/default/python/plugins
 
 Testing
 -------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
-# python packages
-psycopg2
-pytest==3.0.6
-xlwt==1.2.0
+black==19.10b0
+gitlint==0.12.0
+isort==4.3.21
+pre-commit==1.21.0
+pylint==2.4.4
 


### PR DESCRIPTION
Working towards https://github.com/linz/topo-tasks/issues/321

### Change Description:

Adds `pre-commit` to create a `gitlint` configuration

### Notes for Testing:

README updated with installation instructions.

#### Source Code Documentation Tasks:
- [x] README updated (where applicable)
- [x] CHANGELOG (Unreleased section) updated
- [x] Docstrings / comments included to help explain code

#### Testing Tasks:
- [x] Added tests that fail without this change
- [x] All tests are passing in development environment
- [x] Reviewers assigned
