### PR TITLE
Vertex Editing Bug in Alter Relationships and Bulk Load

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Changed
 * Updated NZ Imagery Surveys reference table to NZ Imagery Survey Index
 * metadata updated to reflect additional Bay of Plenty outlines.
 
+Fixed
+-----
+* bulk load outlines and alter relationships edit vertices and split features bug
+
 3.0.0
 ==========
 06-12-2019

--- a/buildings/gui/alter_building_relationships.py
+++ b/buildings/gui/alter_building_relationships.py
@@ -1822,7 +1822,7 @@ class AlterRelationships(QFrame, FORM_CLASS):
                 except TypeError:
                     pass
                 try:
-                    self.lyr_bulk_load.geometryChanged.disconnect(creator_geometry_changed)
+                    self.lyr_bulk_load.geometryChanged.disconnect()
                 except TypeError:
                     pass
                 if self.polyline:

--- a/buildings/gui/alter_building_relationships.py
+++ b/buildings/gui/alter_building_relationships.py
@@ -1854,3 +1854,15 @@ class AlterRelationships(QFrame, FORM_CLASS):
         self.btn_maptool.click()
 
         self.change_instance = None
+
+    def reload_bulk_load_layer(self):
+        """To ensure QGIS has most up to date ID for the newly split feature see #349"""
+        ltl = QgsProject.instance().layerTreeRoot().findLayer(self.lyr_bulk_load.id())
+        ltm = iface.layerTreeView().model()
+        legendNodes = ltm.layerLegendNodes(ltl)
+        legendNode_null = [ln for ln in legendNodes if not ln.data(Qt.DisplayRole)]
+        legendNode_null[0].setData(Qt.Unchecked, Qt.CheckStateRole)
+        legendNode_added = [ln for ln in legendNodes if ln.data(Qt.DisplayRole) == 'Added In Edit']
+        legendNode_added[0].setData(Qt.Unchecked, Qt.CheckStateRole)
+        legendNode_null[0].setData(Qt.Checked, Qt.CheckStateRole)
+        legendNode_added[0].setData(Qt.Checked, Qt.CheckStateRole)

--- a/buildings/gui/alter_building_relationships.py
+++ b/buildings/gui/alter_building_relationships.py
@@ -1809,7 +1809,7 @@ class AlterRelationships(QFrame, FORM_CLASS):
                     pass
             elif isinstance(self.change_instance, bulk_load_changes.EditGeometry):
                 try:
-                    self.lyr_bulk_load.geometryChanged.disconnect()
+                    self.lyr_bulk_load.geometryChanged.disconnect(self.change_instance.geometry_changed)
                 except TypeError:
                     pass
             elif isinstance(self.change_instance, bulk_load_changes.AddBulkLoad):
@@ -1822,7 +1822,7 @@ class AlterRelationships(QFrame, FORM_CLASS):
                 except TypeError:
                     pass
                 try:
-                    self.lyr_bulk_load.geometryChanged.disconnect()
+                    self.lyr_bulk_load.geometryChanged.disconnect(creator_geometry_changed)
                 except TypeError:
                     pass
                 if self.polyline:

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 # from qgis.PyQt.QtCore import pyqtSlot
 from qgis.PyQt.QtWidgets import QToolButton
 from qgis.PyQt.QtCore import Qt
-from qgis.core import QgsFeatureRequest, QgsProject
+from qgis.core import QgsFeatureRequest
 from qgis.utils import Qgis, iface
 
 from buildings.gui.error_dialog import ErrorDialog
@@ -906,25 +906,8 @@ class EditGeometry(BulkLoadChanges):
             self.edit_dialog.editing_layer.triggerRepaint()
 
         if len(self.edit_dialog.split_geoms) > 0:
-            self.edit_dialog.close_dialog()
-            if self.parent_frame.__class__.__name__ == "AlterRelationships":
-                ltl = QgsProject.instance().layerTreeRoot().findLayer(self.parent_frame.lyr_bulk_load.id())
-                ltl.setItemVisibilityChecked(False)
-                ltm = iface.layerTreeView().model()
-                legendNodes = ltm.layerLegendNodes(ltl)
-                legendNode_null = [ln for ln in legendNodes if not ln.data(Qt.DisplayRole)]
-                legendNode_null[0].setData(Qt.Unchecked, Qt.CheckStateRole)
-                legendNode_added = [ln for ln in legendNodes if ln.data(Qt.DisplayRole) == 'Added In Edit']
-                legendNode_added[0].setData(Qt.Unchecked, Qt.CheckStateRole)
-                ltl.setItemVisibilityChecked(True)
-                legendNode_null[0].setData(Qt.Checked, Qt.CheckStateRole)
-                legendNode_added[0].setData(Qt.Checked, Qt.CheckStateRole)
-            else:
-                self.parent_frame.cb_added_clicked(False)
-                self.parent_frame.cb_added_clicked(True)    
-            self.edit_dialog.edit_geometry()
-
-        if commit_status:
+            self.edit_reset_clicked()
+            self.parent_frame.reload_bulk_load_layer()
             self.edit_dialog.split_geoms = {}
 
     # @pyqtSlot()

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -483,7 +483,7 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
                     pass
             elif isinstance(self.change_instance, bulk_load_changes.EditGeometry):
                 try:
-                    self.bulk_load_layer.geometryChanged.disconnect()
+                    self.bulk_load_layer.geometryChanged.disconnect(self.change_instance.geometry_changed)
                 except TypeError:
                     pass
                 try:
@@ -500,7 +500,7 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
                 except TypeError:
                     pass
                 try:
-                    self.bulk_load_layer.geometryChanged.disconnect()
+                    self.bulk_load_layer.geometryChanged.disconnect(creator_geometry_changed)
                 except TypeError:
                     pass
                 if self.polyline:

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -675,3 +675,9 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
             self.btn_bl_save.setDisabled(1)
             self.btn_bl_reset.setDisabled(1)
             return
+
+    def reload_bulk_load_layer(self):
+        """To ensure QGIS has most up to date ID for the newly split feature see #349"""
+        self.cb_added_clicked(False)
+        self.cb_added_clicked(True)
+ 

--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -500,7 +500,7 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
                 except TypeError:
                     pass
                 try:
-                    self.bulk_load_layer.geometryChanged.disconnect(creator_geometry_changed)
+                    self.bulk_load_layer.geometryChanged.disconnect()
                 except TypeError:
                     pass
                 if self.polyline:


### PR DESCRIPTION
Fixes: #349   

### Change Description:
Code added to:
- Fix the described vertex editing bug in alter relationships
- Allow the user to split buildings and then editing the new geometry without having to exit the frame (in both alter relationships and bulk load)

### Notes for Testing:
The functionality to split buildings was not incorporated into the production frame initially. To get this fix in before the next round of QA this has been added to another issue: https://github.com/linz/nz-buildings/issues/354

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
