### PR TITLE
fix: fix splitting logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,15 +7,39 @@ All notable changes to this project will be documented in this file.
 Unreleased
 ==========
 
-Fixed
+Changed
 -------
 
-* Production split features edits tables using correct processes
+* Completed upgrade to QGIS 3.10
+* Some symbology changed to enable the removal of QgsHighlight due to bugs
+* Data dictionary and metadata updated to reflect additional Tasman, Nelson, Otago and Dunedin building outlines updates
+
+Fixed
+-----
+
+* Fixed PostgreSQL installation for continuous integration
+* Outlines deleted or split in production are now added to all_sources table
+* Outlines split in production now cause all split outputs to have new identifiers
+
+3.4.0
+==========
+08-04-2020
 
 Added
 -----
 
 * Users are now able to split features in Production
+
+Changed
+-------
+
+* `make check` uses built installer, not system installer
+
+Fixed
+-----
+
+* Errors that occur during `make check` are better exposed to the user
+* Exit build process immediately if `sqitch` not found
 
 3.3.0
 ==========
@@ -24,7 +48,14 @@ Added
 Added
 -----
 
-* CI runs on push and pull request
+* QGIS plugin now deploys to LINZ QGIS Plugin Repository automatically on version tag
+* Metadata links to ArcGIS Online dataset mirror / ArcGIS REST Services
+
+Changed
+-------
+
+* CI now runs on pull request (to help contribute from forks)
+
 
 3.2.0
 ==========
@@ -65,11 +96,12 @@ Changed
 -------
 
 * Updated NZ Imagery Surveys reference table to NZ Imagery Survey Index
-* metadata updated to reflect additional Bay of Plenty outlines.
+* Metadata updated to reflect additional Bay of Plenty outlines.
 
 Fixed
 -----
-* bulk load outlines and alter relationships edit vertices and split features bug
+
+* Bulk load outlines and alter relationships edit vertices and split features bug
 
 3.0.0
 ==========
@@ -85,7 +117,6 @@ Fixed
 
 * Include name in the update or insert functions for reference data (hut, shelter, bivouac and protected area).
 * Fix sqitch deployment to 'sqitch deploy --verify'
-
 
 2.0.0
 ==========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,28 +8,23 @@ Unreleased
 ==========
 
 Fixed
------
-* CI: fixed postgres installation
-
-Fixed
------
-
-* outlines deleted or split in production are now added to all_sources table
-* Completed Upgrade to QGIS 3.10
-
-Changed
 -------
-* Some symbology changed to enable the removal of QgsHighlight due to bugs
-* Data Dictionary and Metadata updated to reflect additional Tasman, Nelson , Otago and Dunedin building outlines updates.
 
-3.4.0
+* Production split features edits tables using correct processes
+
+Added
+-----
+
+* Users are now able to split features in Production
+
+3.3.0
 ==========
+01-04-2020
 
 Added
 -----
 
 * CI runs on push and pull request
-* Users are now able to split features in Production
 
 3.2.0
 ==========

--- a/buildings/gui/production_edits.ui
+++ b/buildings/gui/production_edits.ui
@@ -33,13 +33,29 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QCheckBox" name="cb_production">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Turn on/off production layers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    <widget class="QGroupBox" name="gb_cb">
+     <property name="title">
+      <string/>
      </property>
-     <property name="text">
-      <string>Production Outline Layers</string>
-     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QCheckBox" name="cb_production">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Turn on/off production layers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Production Outlines</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cb_historic">
+        <property name="text">
+         <string>Historic Outlines</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/buildings/gui/production_frame.py
+++ b/buildings/gui/production_frame.py
@@ -37,10 +37,12 @@ class ProductionFrame(QFrame, FORM_CLASS):
         self.edit_dialog = EditDialog(self)
 
         self.cb_production.setChecked(True)
+        self.cb_historic.setChecked(True)
 
         # set up signals and slots
         self.btn_exit.clicked.connect(self.exit_clicked)
         self.cb_production.clicked.connect(self.cb_production_clicked)
+        self.cb_historic.clicked.connect(self.cb_historic_clicked)
         QgsProject.instance().layerWillBeRemoved.connect(self.layers_removed)
 
         self.setup_toolbar()
@@ -87,7 +89,7 @@ class ProductionFrame(QFrame, FORM_CLASS):
         self.building_historic = self.layer_registry.add_postgres_layer(
             "historic_outlines", "building_outlines", "shape", "buildings", "", "end_lifespan is not NULL"
         )
-        self.building_historic.loadNamedStyle(path + "building_historic.qml")
+        self.building_historic.loadNamedStyle(path + "historic_production_outlines.qml")
         self.building_layer = None
         self.building_layer = self.layer_registry.add_postgres_layer(
             "building_outlines", "building_outlines", "shape", "buildings", "", "end_lifespan is NULL"
@@ -101,6 +103,17 @@ class ProductionFrame(QFrame, FORM_CLASS):
         layer_tree_model = iface.layerTreeView().model()
         categories = layer_tree_model.layerLegendNodes(layer_tree_layer)
         current_category = [ln for ln in categories if ln.data(Qt.DisplayRole) == "Building Outlines"]
+        if checked:
+            current_category[0].setData(Qt.Checked, Qt.CheckStateRole)
+        else:
+            current_category[0].setData(Qt.Unchecked, Qt.CheckStateRole)
+
+    @pyqtSlot(bool)
+    def cb_historic_clicked(self, checked):
+        layer_tree_layer = QgsProject.instance().layerTreeRoot().findLayer(self.building_historic.id())
+        layer_tree_model = iface.layerTreeView().model()
+        categories = layer_tree_model.layerLegendNodes(layer_tree_layer)
+        current_category = [ln for ln in categories if ln.data(Qt.DisplayRole) == "Historic Outlines"]
         if checked:
             current_category[0].setData(Qt.Checked, Qt.CheckStateRole)
         else:
@@ -236,3 +249,5 @@ class ProductionFrame(QFrame, FORM_CLASS):
         """To ensure QGIS has most up to date ID for the newly split feature see #349"""
         self.cb_production_clicked(False)
         self.cb_production_clicked(True)
+        self.cb_historic_clicked(False)
+        self.cb_historic_clicked(True)

--- a/buildings/styles/historic_production_outlines.qml
+++ b/buildings/styles/historic_production_outlines.qml
@@ -1,80 +1,81 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis styleCategories="Symbology" version="3.10.3-A Coruña">
-  <renderer-v2 type="categorizedSymbol" attr="&quot;end_lifespan&quot; is null" forceraster="0" symbollevels="0" enableorderby="0">
+  <renderer-v2 enableorderby="0" attr="&quot;end_lifespan&quot; is not NULL" type="categorizedSymbol" symbollevels="0" forceraster="0">
     <categories>
-      <category symbol="0" value="1" label="Building Outlines" render="true"/>
-      <category symbol="1" value="" label="" render="true"/>
+      <category symbol="0" label="Historic Outlines" render="true" value="1"/>
+      <category symbol="1" label="Other" render="true" value=""/>
     </categories>
     <symbols>
-      <symbol clip_to_extent="1" type="fill" alpha="1" name="0" force_rhr="0">
-        <layer locked="0" class="SimpleFill" enabled="1" pass="0">
+      <symbol type="fill" name="0" alpha="1" force_rhr="0" clip_to_extent="1">
+        <layer pass="0" locked="0" enabled="1" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="104,186,234,0"/>
-          <prop k="joinstyle" v="bevel"/>
+          <prop k="color" v="209,37,161,0"/>
+          <prop k="joinstyle" v="miter"/>
           <prop k="offset" v="0,0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="17,239,255,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.66"/>
+          <prop k="outline_color" v="255,43,1,255"/>
+          <prop k="outline_style" v="dot"/>
+          <prop k="outline_width" v="0.4"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol clip_to_extent="1" type="fill" alpha="1" name="1" force_rhr="0">
-        <layer locked="0" class="SimpleFill" enabled="1" pass="0">
+      <symbol type="fill" name="1" alpha="1" force_rhr="0" clip_to_extent="1">
+        <layer pass="0" locked="0" enabled="1" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="241,238,236,0"/>
-          <prop k="joinstyle" v="bevel"/>
+          <prop k="color" v="81,210,115,0"/>
+          <prop k="joinstyle" v="miter"/>
           <prop k="offset" v="0,0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="247,30,23,0"/>
-          <prop k="outline_style" v="dash"/>
-          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_color" v="255,43,1,0"/>
+          <prop k="outline_style" v="dot"/>
+          <prop k="outline_width" v="0.4"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol clip_to_extent="1" type="fill" alpha="1" name="0" force_rhr="0">
-        <layer locked="0" class="SimpleFill" enabled="1" pass="0">
+      <symbol type="fill" name="0" alpha="1" force_rhr="0" clip_to_extent="1">
+        <layer pass="0" locked="0" enabled="1" class="SimpleFill">
           <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="196,60,57,255"/>
-          <prop k="joinstyle" v="bevel"/>
+          <prop k="color" v="241,86,35,0"/>
+          <prop k="joinstyle" v="miter"/>
           <prop k="offset" v="0,0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_color" v="255,43,1,255"/>
+          <prop k="outline_style" v="dot"/>
+          <prop k="outline_width" v="0.4"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option type="QString" name="name" value=""/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option type="QString" name="type" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </source-symbol>
+    <colorramp type="randomcolors" name="[source]"/>
     <rotation/>
     <sizescale/>
   </renderer-v2>

--- a/db/sql/deploy/buildings/functions/insert_lifecycle_record.sql
+++ b/db/sql/deploy/buildings/functions/insert_lifecycle_record.sql
@@ -1,0 +1,41 @@
+-- Deploy nz-buildings:buildings/functions/insert_lifecycle_record to pg
+
+BEGIN;
+
+--------------------------------------------
+-- buildings.lifecycle
+
+-- Functions:
+-- lifecycle_insert_record (add a single new record to lifecycle table)
+    -- params: integer, integer
+    -- return: building_id
+
+--------------------------------------------
+
+-- Functions
+
+-- lifecycle_insert_record (add new record to lifecycle table)
+    -- params: integer, integer
+    -- return: building_id
+
+CREATE OR REPLACE FUNCTION buildings.lifecycle_insert_record(integer, integer)
+RETURNS integer AS
+$$
+
+    INSERT INTO buildings.lifecycle(
+          parent_building_id
+        , building_id
+    )
+    VALUES(
+        $1, 
+        $2
+    )
+    RETURNING building_id;
+
+$$
+LANGUAGE sql VOLATILE;
+
+COMMENT ON FUNCTION buildings.lifecycle_insert_record(integer, integer) IS
+'Inserts a single new records in lifecycle table';
+
+COMMIT;

--- a/db/sql/revert/buildings/functions/insert_lifecycle_record.sql
+++ b/db/sql/revert/buildings/functions/insert_lifecycle_record.sql
@@ -1,0 +1,7 @@
+-- Revert nz-buildings:buildings/functions/insert_lifecycle_record from pg
+
+BEGIN;
+
+DROP FUNCTION buildings.lifecycle_insert_record(integer, integer);
+
+COMMIT;

--- a/db/sql/sqitch.plan
+++ b/db/sql/sqitch.plan
@@ -73,3 +73,5 @@ buildings_bulk_load/functions/bulk_load_outlines [buildings_bulk_load/functions/
 buildings_bulk_load/functions/remove_small_tanks 2019-12-03T23:56:18Z Megan Davidson <mdavidson@linz.govt.nz> # add a function to remove small tanks on bulk load
 @v3.2.0-dev1 2020-03-02T01:54:14Z Daniel Silk <dsilk@linz.govt.nz> # Tag v3.2.0-dev1
 buildings_lds/functions/populate_buildings_lds [buildings_lds/functions/populate_buildings_lds@v3.2.0-dev1] 2020-05-22T02:23:52Z Jan Ducnuigeen <jducnuigeen@linz.govt.nz> # Remove deleted_in_production where clause
+
+buildings/functions/insert_lifecycle_record 2020-04-29T04:03:16Z Megan Davidson <mdavidson@linz.govt.nz> # Allow the user to insert a record into the lifecycle table

--- a/db/sql/verify/buildings/functions/insert_lifecycle_record.sql
+++ b/db/sql/verify/buildings/functions/insert_lifecycle_record.sql
@@ -1,0 +1,7 @@
+-- Verify nz-buildings:buildings/functions/insert_lifecycle_record on pg
+
+BEGIN;
+
+SELECT has_function_privilege('buildings.lifecycle_insert_record(integer, integer)', 'execute');
+
+ROLLBACK;

--- a/install.py
+++ b/install.py
@@ -93,6 +93,7 @@ SQL_SCRIPTS = [
     os.path.join("sql", "deploy", "buildings_bulk_load", "functions", "supplied_outlines_fix_shape_handling.sql"),
     os.path.join("sql", "deploy", "buildings_reference", "functions", "suburb_locality_optimised.sql"),
     os.path.join("sql", "deploy", "buildings_bulk_load", "functions", "remove_small_tanks.sql"),
+    os.path.join("sql", "deploy", "buildings", "functions", "insert_lifecycle_record.sql"),
 ]
 
 


### PR DESCRIPTION
Fixes: #410  


### Change Description:
Production logic altered to correctly edit a geometry:
- the existing geometry is retained and the lifespan is ended
- the two 'new' geometries are added with new ids
- the old ids and new ids are added to the lifespan table to retain the relationship

### Notes for Testing:
New test added

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
