### PR TITLE
fix: added table alias

### DIFF
--- a/buildings/sql/buildings_bulk_load_select_statements.py
+++ b/buildings/sql/buildings_bulk_load_select_statements.py
@@ -283,9 +283,9 @@ ORDER BY r.building_outline_id ASC;
 
 removed_by_existing_outline_id_dataset_id = """
 SELECT building_outline_id
-FROM buildings_bulk_load.removed
-JOIN buildings_bulk_load.existing_subset_extracts USING (building_outline_id)
-WHERE building_outline_id = %s AND supplied_dataset_id = %s;
+FROM buildings_bulk_load.removed rm
+JOIN buildings_bulk_load.existing_subset_extracts es USING (building_outline_id)
+WHERE rm.building_outline_id = %s AND es.supplied_dataset_id = %s;
 """
 
 removed_count_by_building_outline_id = """


### PR DESCRIPTION
Table alias added to make select statement less ambiguous

Fixes: #497 
Added sql table aliases since new db changes causes both tables to have a supplied_dataset_id column.

### Change Description:

...

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
