### PR TITLE
Dialog warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 * Added the supplied_dataset_id and a new primary key to the buildings_bulk_load.removed table to allow a building to be identified for removal more than once
 * Fixed PostgreSQL installation for continuous integration
 * Outlines split in production now cause all split outputs to have new identifiers
+* Edit dialog doesn't use the error dialog to avoid problem of hidden dialogs
 
 3.5.0
 ==========

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 from qgis.PyQt.QtWidgets import QToolButton, QVBoxLayout
 from qgis.PyQt.QtCore import Qt
 from qgis.core import Qgis, QgsFeatureRequest
-from qgis.gui import QgsMessageBar
 from qgis.utils import Qgis, iface
 
 from buildings.sql import (
@@ -450,10 +449,6 @@ class EditAttribute(BulkLoadChanges):
         """Constructor"""
         BulkLoadChanges.__init__(self, edit_dialog)
 
-        # add message bar
-        self.message_bar = QgsMessageBar()
-        self.edit_dialog.message_bar_layout.addWidget(self.message_bar)
-
         # set editing to edit polygon
         iface.actionSelect().trigger()
         selecttools = iface.attributesToolBar().findChildren(QToolButton)
@@ -498,7 +493,9 @@ class EditAttribute(BulkLoadChanges):
                     "\n -------------------- EMPTY VALUE FIELD ------"
                     '-------------- \n\n There are no "reason for deletion" entries '
                 )
-                self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
+                self.edit_dialog.message_bar.pushMessage(
+                    msg, level=Qgis.Warning, duration=0
+                )
                 self.disable_UI_functions()
                 return
             ls_relationships = self.remove_compared_outlines()
@@ -625,7 +622,9 @@ class EditAttribute(BulkLoadChanges):
                 "features when all existing attributes a"
                 "re identical."
             )
-            self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
+            self.edit_dialog.message_bar.pushMessage(
+                msg, level=Qgis.Warning, duration=0
+            )
 
             return False
         # if all selected features have the same attributes (allowed)
@@ -658,7 +657,7 @@ class EditAttribute(BulkLoadChanges):
                                 "Cannot edit deleted features as have differing"
                                 " reasons for deletion. Please edit individually.\n"
                             )
-                            self.message_bar.pushMessage(
+                            self.edit_dialog.message_bar.pushMessage(
                                 msg, level=Qgis.Warning, duration=0
                             )
 
@@ -670,7 +669,7 @@ class EditAttribute(BulkLoadChanges):
                             " run, instead please add this feature manually.\n"
                             "Note: Don't forget to update the relationship too!"
                         )
-                        self.message_bar.pushMessage(
+                        self.edit_dialog.message_bar.pushMessage(
                             msg, level=Qgis.Warning, duration=0
                         )
                         return False
@@ -799,7 +798,9 @@ class EditAttribute(BulkLoadChanges):
                         "-------\n\nCan only mark for deletion outline if"
                         " no relationship exists"
                     )
-                    self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
+                    self.edit_dialog.message_bar.pushMessage(
+                        msg, level=Qgis.Warning, duration=0
+                    )
                     break
                 # related
                 if (item,) in related_outlines:
@@ -808,7 +809,9 @@ class EditAttribute(BulkLoadChanges):
                         "---------- \n\nCan only mark for deletion outline if"
                         " no relationship exists"
                     )
-                    self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
+                    self.edit_dialog.message_bar.pushMessage(
+                        msg, level=Qgis.Warning, duration=0
+                    )
                     ls_relationships["related"].append(item)
                     break
         return ls_relationships
@@ -1016,7 +1019,9 @@ class EditGeometry(BulkLoadChanges):
                 "this can't be done in edit geometry, "
                 "please switch to add outline."
             )
-            self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
+            self.edit_dialog.message_bar.pushMessage(
+                msg, level=Qgis.Warning, duration=0
+            )
             self.disable_UI_functions()
             self.edit_dialog.btn_edit_reset.setEnabled(1)
             return

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -2,7 +2,7 @@
 from collections import OrderedDict
 
 # from qgis.PyQt.QtCore import pyqtSlot
-from qgis.PyQt.QtWidgets import QToolButton, QVBoxLayout
+from qgis.PyQt.QtWidgets import QToolButton
 from qgis.PyQt.QtCore import Qt
 from qgis.core import Qgis, QgsFeatureRequest
 from qgis.utils import Qgis, iface

--- a/buildings/gui/bulk_load_changes.py
+++ b/buildings/gui/bulk_load_changes.py
@@ -2,12 +2,12 @@
 from collections import OrderedDict
 
 # from qgis.PyQt.QtCore import pyqtSlot
-from qgis.PyQt.QtWidgets import QToolButton
+from qgis.PyQt.QtWidgets import QToolButton, QVBoxLayout
 from qgis.PyQt.QtCore import Qt
-from qgis.core import QgsFeatureRequest
+from qgis.core import Qgis, QgsFeatureRequest
+from qgis.gui import QgsMessageBar
 from qgis.utils import Qgis, iface
 
-from buildings.gui.error_dialog import ErrorDialog
 from buildings.sql import (
     buildings_bulk_load_select_statements as bulk_load_select,
     buildings_common_select_statements as common_select,
@@ -23,7 +23,6 @@ class BulkLoadChanges(object):
         """Constructor."""
         # setup
         self.edit_dialog = edit_dialog
-        self.error_dialog = None
         self.parent_frame = self.edit_dialog.parent_frame
         self.editing_layer = self.edit_dialog.editing_layer
         iface.setActiveLayer(self.editing_layer)
@@ -41,7 +40,9 @@ class BulkLoadChanges(object):
 
         if self.edit_dialog.layout_capture_method.isVisible():
             # populate capture method combobox
-            result = self.edit_dialog.db.execute_return(common_select.capture_method_value)
+            result = self.edit_dialog.db.execute_return(
+                common_select.capture_method_value
+            )
             ls = result.fetchall()
             for item in ls:
                 self.edit_dialog.cmb_capture_method.addItem(item[0])
@@ -217,16 +218,20 @@ class AddBulkLoad(BulkLoadChanges):
         # editing actions
         iface.building_toolbar.addSeparator()
         for dig in iface.digitizeToolBar().actions():
-            if dig.objectName() in ["mActionAddFeature", "mActionVertexTool", "mActionMoveFeature"]:
+            if dig.objectName() in [
+                "mActionAddFeature",
+                "mActionVertexTool",
+                "mActionMoveFeature",
+            ]:
                 iface.building_toolbar.addAction(dig)
         # advanced Actions
         iface.building_toolbar.addSeparator()
         for adv in iface.advancedDigitizeToolBar().actions():
             if adv.objectName() in [
-                    "mActionUndo",
-                    "mActionRedo",
-                    "mActionReshapeFeatures",
-                    "mActionOffsetCurve",
+                "mActionUndo",
+                "mActionRedo",
+                "mActionReshapeFeatures",
+                "mActionOffsetCurve",
             ]:
                 iface.building_toolbar.addAction(adv)
         iface.building_toolbar.show()
@@ -444,6 +449,11 @@ class EditAttribute(BulkLoadChanges):
     def __init__(self, edit_dialog):
         """Constructor"""
         BulkLoadChanges.__init__(self, edit_dialog)
+
+        # add message bar
+        self.message_bar = QgsMessageBar()
+        self.edit_dialog.message_bar_layout.addWidget(self.message_bar)
+
         # set editing to edit polygon
         iface.actionSelect().trigger()
         selecttools = iface.attributesToolBar().findChildren(QToolButton)
@@ -484,18 +494,17 @@ class EditAttribute(BulkLoadChanges):
                 self.edit_dialog.le_deletion_reason.text()
             )
             if len(self.edit_dialog.description_del) == 0:
-                self.error_dialog = ErrorDialog()
-                self.error_dialog.fill_report(
+                msg = (
                     "\n -------------------- EMPTY VALUE FIELD ------"
                     '-------------- \n\n There are no "reason for deletion" entries '
                 )
-                self.error_dialog.show()
+                self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
                 self.disable_UI_functions()
                 return
             ls_relationships = self.remove_compared_outlines()
             if (
-                    len(ls_relationships["matched"]) == 0
-                    and len(ls_relationships["related"]) == 0
+                len(ls_relationships["matched"]) == 0
+                and len(ls_relationships["related"]) == 0
             ):
                 if len(self.edit_dialog.ids) > 0:
                     # Send signal to LIQA through edit dialog
@@ -610,14 +619,14 @@ class EditAttribute(BulkLoadChanges):
                 feats.append(ls)
         # if selected features have different attributes (not allowed)
         if len(feats) > 1:
-            self.error_dialog = ErrorDialog()
-            self.error_dialog.fill_report(
+            msg = (
                 "\n ---- MULTIPLE NON IDENTICAL FEATURES SELECTED"
                 " ---- \n\n Can only edit attributes of multiple"
                 "features when all existing attributes a"
                 "re identical."
             )
-            self.error_dialog.show()
+            self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
+
             return False
         # if all selected features have the same attributes (allowed)
         elif len(feats) == 1:
@@ -644,23 +653,26 @@ class EditAttribute(BulkLoadChanges):
                         if len(reasons) <= 1:
                             return True
                         else:
-                            self.error_dialog = ErrorDialog()
-                            self.error_dialog.fill_report(
+                            msg = (
                                 "\n ---- DIFFERING DELETION REASONS ---- \n\n"
                                 "Cannot edit deleted features as have differing"
                                 " reasons for deletion. Please edit individually.\n"
                             )
-                            self.error_dialog.show()
+                            self.message_bar.pushMessage(
+                                msg, level=Qgis.Warning, duration=0
+                            )
+
                             return False
                     else:
-                        self.error_dialog = ErrorDialog()
-                        self.error_dialog.fill_report(
+                        msg = (
                             "\n ---- CANNOT EDIT DELETED FEATURE ---- \n\n"
                             "Cannot edit deleted feature after comparison has been"
                             " run, instead please add this feature manually.\n"
                             "Note: Don't forget to update the relationship too!"
                         )
-                        self.error_dialog.show()
+                        self.message_bar.pushMessage(
+                            msg, level=Qgis.Warning, duration=0
+                        )
                         return False
             else:
                 return True
@@ -781,24 +793,22 @@ class EditAttribute(BulkLoadChanges):
                     ls_relationships["added"].append(item)
                 # matched
                 if (item,) in matched_outlines:
-                    self.error_dialog = ErrorDialog()
-                    self.error_dialog.fill_report(
+                    ls_relationships["matched"].append(item)
+                    msg = (
                         "\n --------------- RELATIONSHIP EXISTS ---------"
                         "-------\n\nCan only mark for deletion outline if"
                         " no relationship exists"
                     )
-                    self.error_dialog.show()
-                    ls_relationships["matched"].append(item)
+                    self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
                     break
                 # related
                 if (item,) in related_outlines:
-                    self.error_dialog = ErrorDialog()
-                    self.error_dialog.fill_report(
+                    msg = (
                         "\n ------------------- RELATIONSHIP EXISTS ---------"
                         "---------- \n\nCan only mark for deletion outline if"
                         " no relationship exists"
                     )
-                    self.error_dialog.show()
+                    self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
                     ls_relationships["related"].append(item)
                     break
         return ls_relationships
@@ -829,11 +839,11 @@ class EditGeometry(BulkLoadChanges):
         iface.building_toolbar.addSeparator()
         for adv in iface.advancedDigitizeToolBar().actions():
             if adv.objectName() in [
-                    "mActionUndo",
-                    "mActionRedo",
-                    "mActionReshapeFeatures",
-                    "mActionOffsetCurve",
-                    "mActionSplitFeatures",
+                "mActionUndo",
+                "mActionRedo",
+                "mActionReshapeFeatures",
+                "mActionOffsetCurve",
+                "mActionSplitFeatures",
             ]:
                 iface.building_toolbar.addAction(adv)
         iface.building_toolbar.show()
@@ -1000,14 +1010,13 @@ class EditGeometry(BulkLoadChanges):
         new_feature = next(self.editing_layer.getFeatures(request))
         self.new_attrs[qgsfId] = new_feature.attributes()
         if not self.new_attrs[qgsfId][5]:
-            self.error_dialog = ErrorDialog()
-            self.error_dialog.fill_report(
+            msg = (
                 "\n -------------------- CANNOT ADD NEW FEATURE ------"
                 "-------------- \n\nYou've added a new feature, "
                 "this can't be done in edit geometry, "
                 "please switch to add outline."
             )
-            self.error_dialog.show()
+            self.message_bar.pushMessage(msg, level=Qgis.Warning, duration=0)
             self.disable_UI_functions()
             self.edit_dialog.btn_edit_reset.setEnabled(1)
             return

--- a/buildings/gui/edit_dialog.py
+++ b/buildings/gui/edit_dialog.py
@@ -8,13 +8,16 @@ from qgis.PyQt.QtWidgets import QCompleter, QDialog
 from qgis.PyQt.QtCore import Qt, pyqtSignal, pyqtSlot
 
 from qgis.core import QgsProject
+from qgis.gui import QgsMessageBar
 from qgis.utils import iface
 
 from buildings.gui import bulk_load_changes, production_changes
 from buildings.sql import buildings_bulk_load_select_statements as bulk_load_select
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-FORM_CLASS, _ = uic.loadUiType(os.path.join(os.path.dirname(__file__), "edit_dialog.ui"))
+FORM_CLASS, _ = uic.loadUiType(
+    os.path.join(os.path.dirname(__file__), "edit_dialog.ui")
+)
 
 
 class EditDialog(QDialog, FORM_CLASS):
@@ -46,6 +49,10 @@ class EditDialog(QDialog, FORM_CLASS):
         elif self.parent_frame_name == "ProductionFrame":
             self.editing_layer = self.parent_frame.building_layer
             self.current_dataset = None
+
+        # add message bar
+        self.message_bar = QgsMessageBar()
+        self.message_bar_layout.addWidget(self.message_bar)
 
         self.init_dialog()
 
@@ -95,7 +102,12 @@ class EditDialog(QDialog, FORM_CLASS):
         iface.actionCancelEdits().trigger()
         # reset toolbar
         for action in iface.building_toolbar.actions():
-            if action.text() not in ["Pan Map", "Add Outline", "Edit Geometry", "Edit Attributes"]:
+            if action.text() not in [
+                "Pan Map",
+                "Add Outline",
+                "Edit Geometry",
+                "Edit Attributes",
+            ]:
                 iface.building_toolbar.removeAction(action)
             if action.text() == "Add Outline":
                 action.setDisabled(True)
@@ -111,7 +123,10 @@ class EditDialog(QDialog, FORM_CLASS):
         except TypeError:
             pass
 
-        if self.parent_frame_name == "BulkLoadFrame" or self.parent_frame_name == "AlterRelationships":
+        if (
+            self.parent_frame_name == "BulkLoadFrame"
+            or self.parent_frame_name == "AlterRelationships"
+        ):
             self.change_instance = bulk_load_changes.AddBulkLoad(self)
             self.layout_status.hide()
             self.layout_capture_method.show()
@@ -127,11 +142,19 @@ class EditDialog(QDialog, FORM_CLASS):
             self.layout_end_lifespan.hide()
 
         # connect signals and slots
-        self.btn_edit_save.clicked.connect(partial(self.change_instance.edit_save_clicked, True))
+        self.btn_edit_save.clicked.connect(
+            partial(self.change_instance.edit_save_clicked, True)
+        )
         self.btn_edit_reset.clicked.connect(self.change_instance.edit_reset_clicked)
-        self.editing_layer.featureAdded.connect(self.change_instance.creator_feature_added)
-        self.editing_layer.featureDeleted.connect(self.change_instance.creator_feature_deleted)
-        self.editing_layer.geometryChanged.connect(self.change_instance.creator_geometry_changed)
+        self.editing_layer.featureAdded.connect(
+            self.change_instance.creator_feature_added
+        )
+        self.editing_layer.featureDeleted.connect(
+            self.change_instance.creator_feature_deleted
+        )
+        self.editing_layer.geometryChanged.connect(
+            self.change_instance.creator_geometry_changed
+        )
 
     def edit_attribute(self):
         """When the user selects to edit a building attribute"""
@@ -141,7 +164,12 @@ class EditDialog(QDialog, FORM_CLASS):
         iface.actionCancelEdits().trigger()
         # reset toolbar
         for action in iface.building_toolbar.actions():
-            if action.text() not in ["Pan Map", "Add Outline", "Edit Geometry", "Edit Attributes"]:
+            if action.text() not in [
+                "Pan Map",
+                "Add Outline",
+                "Edit Geometry",
+                "Edit Attributes",
+            ]:
                 iface.building_toolbar.removeAction(action)
             if action.text() in ["Edit Attributes"]:
                 action.setDisabled(True)
@@ -156,7 +184,10 @@ class EditDialog(QDialog, FORM_CLASS):
         except TypeError:
             pass
 
-        if self.parent_frame_name == "BulkLoadFrame" or self.parent_frame_name == "AlterRelationships":
+        if (
+            self.parent_frame_name == "BulkLoadFrame"
+            or self.parent_frame_name == "AlterRelationships"
+        ):
             self.change_instance = bulk_load_changes.EditAttribute(self)
             self.layout_status.show()
             self.layout_capture_method.show()
@@ -175,12 +206,18 @@ class EditDialog(QDialog, FORM_CLASS):
                 self.btn_end_lifespan.clicked.disconnect()
             except Exception:
                 pass
-            self.btn_end_lifespan.clicked.connect(partial(self.change_instance.end_lifespan, True))
+            self.btn_end_lifespan.clicked.connect(
+                partial(self.change_instance.end_lifespan, True)
+            )
 
         # set up signals and slots
-        self.btn_edit_save.clicked.connect(partial(self.change_instance.edit_save_clicked, True))
+        self.btn_edit_save.clicked.connect(
+            partial(self.change_instance.edit_save_clicked, True)
+        )
         self.btn_edit_reset.clicked.connect(self.change_instance.edit_reset_clicked)
-        self.editing_layer.selectionChanged.connect(self.change_instance.selection_changed)
+        self.editing_layer.selectionChanged.connect(
+            self.change_instance.selection_changed
+        )
 
     def edit_geometry(self):
         """"When the user selects to edit a building geometry"""
@@ -189,7 +226,12 @@ class EditDialog(QDialog, FORM_CLASS):
         iface.actionCancelEdits().trigger()
         # reset toolbar
         for action in iface.building_toolbar.actions():
-            if action.text() not in ["Pan Map", "Add Outline", "Edit Geometry", "Edit Attributes"]:
+            if action.text() not in [
+                "Pan Map",
+                "Add Outline",
+                "Edit Geometry",
+                "Edit Attributes",
+            ]:
                 iface.building_toolbar.removeAction(action)
             if action.text() == "Edit Geometry":
                 action.setDisabled(True)
@@ -204,7 +246,10 @@ class EditDialog(QDialog, FORM_CLASS):
         except TypeError:
             pass
 
-        if self.parent_frame_name == "BulkLoadFrame" or self.parent_frame_name == "AlterRelationships":
+        if (
+            self.parent_frame_name == "BulkLoadFrame"
+            or self.parent_frame_name == "AlterRelationships"
+        ):
             self.change_instance = bulk_load_changes.EditGeometry(self)
             self.layout_status.hide()
             self.layout_capture_method.show()
@@ -220,10 +265,16 @@ class EditDialog(QDialog, FORM_CLASS):
             self.layout_end_lifespan.hide()
 
         # set up signals and slots
-        self.btn_edit_save.clicked.connect(partial(self.change_instance.edit_save_clicked, True))
+        self.btn_edit_save.clicked.connect(
+            partial(self.change_instance.edit_save_clicked, True)
+        )
         self.btn_edit_reset.clicked.connect(self.change_instance.edit_reset_clicked)
-        self.editing_layer.geometryChanged.connect(self.change_instance.geometry_changed)
-        self.editing_layer.featureAdded.connect(self.change_instance.creator_feature_added)
+        self.editing_layer.geometryChanged.connect(
+            self.change_instance.geometry_changed
+        )
+        self.editing_layer.featureAdded.connect(
+            self.change_instance.creator_feature_added
+        )
 
     def close_dialog(self):
         """When 'x' is clicked"""
@@ -238,7 +289,12 @@ class EditDialog(QDialog, FORM_CLASS):
 
         self.parent_frame.edit_cancel_clicked()
         for action in iface.building_toolbar.actions():
-            if action.text() not in ["Pan Map", "Add Outline", "Edit Geometry", "Edit Attributes"]:
+            if action.text() not in [
+                "Pan Map",
+                "Add Outline",
+                "Edit Geometry",
+                "Edit Attributes",
+            ]:
                 iface.building_toolbar.removeAction(action)
             else:
                 action.setEnabled(True)
@@ -277,8 +333,12 @@ class EditDialog(QDialog, FORM_CLASS):
             bulk_load_ids = self.get_bulk_load_ids(qa_lyr)
             for feat_id in ids:
                 if feat_id in list(bulk_load_ids.values()):
-                    qa_feat_id = list(bulk_load_ids.keys())[list(bulk_load_ids.values()).index(feat_id)]
-                    self.update_qa_layer_attribute(qa_lyr, qa_feat_id, "Fixed", "Geometry edited")
+                    qa_feat_id = list(bulk_load_ids.keys())[
+                        list(bulk_load_ids.values()).index(feat_id)
+                    ]
+                    self.update_qa_layer_attribute(
+                        qa_lyr, qa_feat_id, "Fixed", "Geometry edited"
+                    )
 
     @pyqtSlot(list, str)
     def liqa_on_delete_outline_saved(self, ids, del_reason):
@@ -289,8 +349,12 @@ class EditDialog(QDialog, FORM_CLASS):
             bulk_load_ids = self.get_bulk_load_ids(qa_lyr)
             for feat_id in ids:
                 if feat_id in list(bulk_load_ids.values()):
-                    qa_feat_id = list(bulk_load_ids.keys())[list(bulk_load_ids.values()).index(feat_id)]
-                    self.update_qa_layer_attribute(qa_lyr, qa_feat_id, "Fixed", "Deleted- {}".format(del_reason))
+                    qa_feat_id = list(bulk_load_ids.keys())[
+                        list(bulk_load_ids.values()).index(feat_id)
+                    ]
+                    self.update_qa_layer_attribute(
+                        qa_lyr, qa_feat_id, "Fixed", "Deleted- {}".format(del_reason)
+                    )
 
     def bulk_load_id_field_exists(self, qa_layer):
         field_names = [field.name() for field in qa_layer.fields()]

--- a/buildings/gui/edit_dialog.ui
+++ b/buildings/gui/edit_dialog.ui
@@ -36,6 +36,9 @@
    </property>
    <layout class="QVBoxLayout" name="verticalLayout_2">
     <item>
+     <layout class="QVBoxLayout" name="message_bar_layout"/>
+    </item>
+    <item>
      <widget class="QWidget" name="layout_status" native="true">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Maximum">

--- a/buildings/tests/gui/test_processes_edit_attribute_bulk_load.py
+++ b/buildings/tests/gui/test_processes_edit_attribute_bulk_load.py
@@ -31,6 +31,7 @@ from qgis.gui import QgsMapTool
 from qgis.utils import plugins, iface
 
 from buildings.utilities import database as db
+from buildings.tests.test_utilities import clear_message_bar
 
 
 class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
@@ -289,7 +290,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         for action in iface.building_toolbar.actions():
             if action.text() == "Edit Attributes":
                 action.trigger()
-        self.bulk_load_frame.change_instance.error_dialog.close()
+        clear_message_bar(self.edit_dialog.message_bar)
         self.assertFalse(self.edit_dialog.btn_edit_save.isEnabled())
         self.assertFalse(self.edit_dialog.btn_edit_reset.isEnabled())
         self.assertFalse(self.edit_dialog.cmb_capture_method.isEnabled())
@@ -645,7 +646,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         )
         self.edit_dialog.le_deletion_reason.setText("Reason for deletion")
         self.bulk_load_frame.change_instance.edit_save_clicked(False)
-        self.bulk_load_frame.change_instance.error_dialog.close()
+        clear_message_bar(self.edit_dialog.message_bar)
         sql = "SELECT bulk_load_status_id FROM buildings_bulk_load.bulk_load_outlines WHERE bulk_load_outline_id = %s;"
         result = db._execute(sql, (self.edit_dialog.bulk_load_outline_id,))
         result = result.fetchall()[0]
@@ -713,7 +714,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         self.edit_dialog.le_deletion_reason.setText("")
 
         self.bulk_load_frame.change_instance.edit_save_clicked(False)
-        self.bulk_load_frame.change_instance.error_dialog.close()
+        clear_message_bar(self.edit_dialog.message_bar)
 
         sql = "SELECT bulk_load_status_id FROM buildings_bulk_load.bulk_load_outlines WHERE bulk_load_outline_id = %s;"
         result = db._execute(sql, (self.edit_dialog.bulk_load_outline_id,))
@@ -749,7 +750,7 @@ class ProcessBulkLoadEditOutlinesTest(unittest.TestCase):
         )
         self.edit_dialog.le_deletion_reason.setText("Reason for deletion")
         self.bulk_load_frame.change_instance.edit_save_clicked(False)
-        self.bulk_load_frame.change_instance.error_dialog.close()
+        clear_message_bar(self.edit_dialog.message_bar)
         sql = "SELECT bulk_load_status_id FROM buildings_bulk_load.bulk_load_outlines WHERE bulk_load_outline_id = 2003 OR bulk_load_outline_id = 2004;"
         result = db._execute(sql)
         result = result.fetchall()

--- a/buildings/tests/test_utilities.py
+++ b/buildings/tests/test_utilities.py
@@ -1,0 +1,10 @@
+def clear_message_bar(messagebar):
+    """Deletes all messages in a message bar"""
+
+    layout = messagebar.layout()
+    while layout.count():
+        child = layout.takeAt(0)
+        if child.widget() is not None:
+            child.widget().deleteLater()
+        elif child.layout() is not None:
+            self.clear_layout(child.layout())


### PR DESCRIPTION
Fixes: #461

### Change Description:

For the edit dialog instead of creating an error dialog we now have qgsmessagebar at the top of the dialog which populates with the error message.
The error message is warning level so it is highlighted, and has a time of 0 set so it doesn't disappear without the user removing it.
A layout has been added to the ui so this can be filled with the qgsmessagebar when initiating the edit dialog.

Only edit dialog adjust no other dialogs which also use the error dialog. If further ones cause problems these too can have a message bar added.

![image](https://user-images.githubusercontent.com/15041585/123338879-a6cd8280-d59d-11eb-9b86-f7c45c0fd990.png)

### Notes for Testing:

Modified test which failed as the closed the error dialog associated with the edit dialog, and this no longer exists. Instead of closing I clear all messages from the message bar. This is currently not really needed as we never check these messages, but left as should be useful should we test the error messages in the future.
Did not create new tests as it is pyqgis functionality, nothing really unique I have added. And can't replicate hidden dialog error.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [x] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [x] All tests are passing in development environment
- [x] Reviewers assigned
- [x] Linked to main issue for ZenHub board
