### PR TITLE
Add logging capability

### DIFF
--- a/buildings/plugin.py
+++ b/buildings/plugin.py
@@ -14,6 +14,7 @@ from qgis.utils import iface, plugins
 from buildings.gui.dockwidget import BuildingsDockwidget
 from buildings.gui.menu_frame import MenuFrame
 from buildings.settings.project import get_attribute_dialog_setting, set_attribute_dialog_setting
+from buildings.utilities.log import configure_logger
 
 # Get the path for the parent directory of this file.
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -26,6 +27,8 @@ class Buildings(object):
 
     def __init__(self, iface):
         """Constructor."""
+
+        configure_logger()
 
         # Store original enter attribute values dialog setting
         self.attribute_dialog_setting = get_attribute_dialog_setting()

--- a/buildings/tests/config.ini
+++ b/buildings/tests/config.ini
@@ -1,0 +1,9 @@
+[database]
+host = db
+port = 54320
+dbname = buildings
+user = buildings
+password = buildings
+
+[logging]
+logfile = ~/buildings.log

--- a/buildings/tests/pg_config_test.ini
+++ b/buildings/tests/pg_config_test.ini
@@ -1,6 +1,0 @@
-[localhost]
-host=db
-port=54320
-dbname=buildings
-user=buildings
-password=buildings

--- a/buildings/utilities/config.py
+++ b/buildings/utilities/config.py
@@ -2,29 +2,64 @@
 
 """This module converts .ini files to Python objects."""
 
-import configparser
 import os
+from configparser import ConfigParser
+from typing import Dict, List, Optional
+
+from qgis.core import QgsApplication
+
+CONFIG_FILE_PATH = os.path.join(QgsApplication.qgisSettingsDirPath(), "buildings", "config.ini")
+CONFIG_SCHEMA = {
+    "database": ["host", "port", "dbname", "user", "password"],
+    "logging": ["logfile"]
+}
 
 
-def _parse_config_to_dict(config_parser):
-    """Returns a dictionary containing config section names as the key and
-    a dictionary of config item names and config item values as the value.
-    e.g. config['section_name']['item_name'] provides the item_value.
+def validate_config(config: Dict[str, List[str]]) -> Optional[List[str]]:
     """
-    config = {}
-    for section in config_parser.sections():
-        config[section] = dict(config_parser.items(section))
-    return config
+    Checks that the supplied config has the same sections and keys as CONFIG_SCHEMA.
+    Values are not validated. If there are any errors, we return a list of strings
+    describing each error.
+    """
+    errors = []
+    for schema_section, schema_keys in CONFIG_SCHEMA.items():
+        config_section = config.get(schema_section, None)
+        if config_section is None:
+            errors.append(f"- Section [{schema_section}] missing")
+        else:
+            for schema_key in schema_keys:
+                if schema_key not in config_section:
+                    errors.append(f'- Key "{schema_key}" missing from section [{schema_section}]')
+    if errors:
+        return errors
 
 
-def read_config_file(file_path):
-    """Check that the provided config file name exists and if so, read it into a
-    ConfigParser() object"""
-    config_parser = None
-    if os.path.isfile(file_path):
-        config_parser = configparser.ConfigParser()
-        config_parser.read(file_path)
-    else:
-        raise IOError("Config file not found.")
-    config = _parse_config_to_dict(config_parser)
+def read_config_file(file_path: os.PathLike = CONFIG_FILE_PATH) -> Dict[str, Dict[str, str]]:
+    """
+    Parses the config file from disk, and returns its contents as a dictionary with keys of each
+    ini section, and and values of a dictionary of key value pairs of items inside that section.
+
+    # Example ini file
+    [section]
+    key_1 = value_1
+    key_2 = value_2
+
+    # Parsed dictionary
+    {"section": {"key_1": "value_1", "key_2": "value_2"}}
+
+    A RuntimeError exception will be raised if the config file (defined in CONFIG_FILE_PATH) either
+    does not exist, is unable to be parsed, or does not contain the required sections and keys
+    (defined in CONFIG_SCHEMA).
+    """
+    if not os.path.isfile(file_path):
+        raise RuntimeError(f'Config file "{CONFIG_FILE_PATH}" not found.')
+    try:
+        parser = ConfigParser()
+        parser.read(file_path)
+        config = {section: dict(parser.items(section)) for section in parser.sections()}
+    except Exception as err:
+        raise RuntimeError(f'Unable to parse config file "{CONFIG_FILE_PATH}"') from err
+    validation_errors = validate_config(config)
+    if validation_errors is not None:
+        raise RuntimeError(f'Config file "{CONFIG_FILE_PATH}" has errors:\n' + "\n".join(validation_errors))
     return config

--- a/buildings/utilities/database.py
+++ b/buildings/utilities/database.py
@@ -14,23 +14,22 @@
 from __future__ import absolute_import
 from builtins import str
 
-import os
 import psycopg2
+from qgis.core import QgsDataSourceUri
 
 from buildings.utilities.warnings import buildings_warning
-from qgis.core import QgsDataSourceUri, QgsApplication
+from buildings.utilities.config import read_config_file
 
-from . import config
-
-
-config_path = os.path.join(QgsApplication.qgisSettingsDirPath(), "buildings", "pg_config.ini")
-
-pg_config = config.read_config_file(config_path)
-_host = pg_config["localhost"]["host"]
-_port = pg_config["localhost"]["port"]
-_dbname = pg_config["localhost"]["dbname"]
-_user = pg_config["localhost"]["user"]
-_pw = pg_config["localhost"]["password"]
+try:
+    DB_CONFIG = read_config_file()["database"]
+except RuntimeError as error:
+    buildings_warning("Config file error", str(error), "critical")
+    raise error
+_host = DB_CONFIG["host"]
+_port = DB_CONFIG["port"]
+_dbname = DB_CONFIG["dbname"]
+_user = DB_CONFIG["user"]
+_pw = DB_CONFIG["password"]
 
 _open_cursor = None
 

--- a/buildings/utilities/log.py
+++ b/buildings/utilities/log.py
@@ -1,0 +1,49 @@
+import logging
+import logging.handlers
+from pathlib import Path
+
+from qgis.core import Qgis, QgsApplication
+
+from buildings.utilities.config import read_config_file
+from buildings.utilities.warnings import buildings_warning
+
+MAX_LOGFILE_SIZE = 1024*20  # Maximum file size before a logfile will be rotated, in bytes
+
+
+class QgsHandler(logging.Handler):
+    """Custom logging handler to print logs to QGIS GUI logging panel."""
+    def emit(self, record: logging.LogRecord):
+        if record.levelname == ("CRITICAL", "ERROR"):
+            level = Qgis.Critical
+        elif record.levelname == "WARNING":
+            level = Qgis.Warning
+        else:
+            level = Qgis.Info
+        QgsApplication.messageLog().logMessage(message=self.format(record), level=level)
+
+
+def get_logfile_path() -> Path:
+    """Gets the path of the logfile from the plugin config file."""
+    try:
+        raw_path = read_config_file()["logging"]["logfile"]
+    except ValueError as error:
+        buildings_warning("Config file error", str(error), "critical")
+        raise error
+    logfile = Path(raw_path)
+    logfile = logfile.expanduser().resolve()
+    return logfile
+
+
+def configure_logger():
+    """Configures logs to go to both the logfile defined in the config, and the QGIS GUI logging panel"""
+    logger = logging.getLogger("buildings")
+    logger.setLevel(logging.DEBUG)
+    qgis_handler = QgsHandler()
+    qgis_formatter = logging.Formatter(fmt="[{name}]  {message}", style="{")
+    qgis_handler.setFormatter(qgis_formatter)
+    logger.addHandler(qgis_handler)
+    logfile = get_logfile_path()
+    file_handler = logging.handlers.RotatingFileHandler(logfile, encoding="utf8", maxBytes=MAX_LOGFILE_SIZE)
+    file_formatter = logging.Formatter(fmt="{asctime}  {name}  {levelname}  {message}", datefmt="%Y-%m-%dT%H:%M:%S", style="{")
+    file_handler.setFormatter(file_formatter)
+    logger.addHandler(file_handler)

--- a/buildings/utilities/log.py
+++ b/buildings/utilities/log.py
@@ -19,7 +19,7 @@ class QgsHandler(logging.Handler):
             level = Qgis.Warning
         else:
             level = Qgis.Info
-        QgsApplication.messageLog().logMessage(message=self.format(record), level=level)
+        QgsApplication.messageLog().logMessage(message=self.format(record), tag="Buildings", level=level)
 
 
 def get_logfile_path() -> Path:
@@ -44,6 +44,6 @@ def configure_logger():
     logger.addHandler(qgis_handler)
     logfile = get_logfile_path()
     file_handler = logging.handlers.RotatingFileHandler(logfile, encoding="utf8", maxBytes=MAX_LOGFILE_SIZE)
-    file_formatter = logging.Formatter(fmt="{asctime}  {name}  {levelname}  {message}", datefmt="%Y-%m-%dT%H:%M:%S", style="{")
+    file_formatter = logging.Formatter(fmt="{asctime}  {levelname}  [{name}]  {message}", datefmt="%Y-%m-%dT%H:%M:%S", style="{")
     file_handler.setFormatter(file_formatter)
     logger.addHandler(file_handler)

--- a/scripts/steps/setup_qgis_plugin.sh
+++ b/scripts/steps/setup_qgis_plugin.sh
@@ -9,5 +9,5 @@ echo >&2 ""
 PROFILE_DIR=/root/.local/share/QGIS/QGIS3/profiles/default
 
 docker exec qgis mkdir -p $PROFILE_DIR/buildings
-docker exec qgis cp /tests_directory/buildings/tests/pg_config_test.ini $PROFILE_DIR/buildings/pg_config.ini
+docker exec qgis cp /tests_directory/buildings/tests/config.ini $PROFILE_DIR/buildings/config.ini
 docker exec qgis qgis_setup.sh buildings


### PR DESCRIPTION
This pull request implements the capability for logging, but does not itself implement any logging messages (to be implemented in further pull requests).

Logs are configured to be sent both to a logfile and to the QGIS GUI logs panel.

The logfile location is defined in the INI config file. Previously this INI file only stored database connection parameters, so the code which parses this has been expanded to account for the new information.

**This means the INI config file in use on any installations will need to be updated to include a logfile location.**

The following pattern can be used to add logging to a desired module:

```python
import logging
logger = logging.getLogger(__name__)
logger.info("Hello world")
```

Using `__name__` as the logger name will correctly scope the logger instance as a child of the configured parent logger, and allow the messages to include the module from where the message was generated.

A `RotatingFileHandler` is used for writing logs to a file, which will rotate to a new file when the specified maximum size of 20MB has been reached.