### PR TITLE
fix: adjust existing subset buildings

### DIFF
--- a/buildings/sql/buildings_select_statements.py
+++ b/buildings/sql/buildings_select_statements.py
@@ -31,7 +31,7 @@ WHERE building_outline_id = %s;
 building_outlines_intersect_geometry = """
 SELECT *
 FROM buildings.building_outlines bo
-WHERE ST_Intersects(bo.shape, %s)
+WHERE ST_Within(bo.shape, %s)
 AND bo.building_outline_id NOT IN (
     SELECT building_outline_id
     FROM buildings_bulk_load.removed


### PR DESCRIPTION
Currently when we start a comparison in alter relationships, the existing subset building outlines include buildings which cross the capture source boundary.
Since Lynker does not provide these buildings that cross the boundary, we have been noticing the alter relationships results show many buildings on the boundary as "removed", since those were not captured.

I struggle sometimes to follow what the plugin is doing, but from what I can tell the existing subset outline table is not populated until the comparisons step is run. I think.
If this is true, then when the comparisons.py script is run, in line 22:
```buildings_select.building_outlines_intersect_geometry, (hull,)```
the building outlines intersect geometry statement is run, and that is using an ST_Intersects, while it probably should be using an ST_Within.

However, I'm not sure there are other implications for this affecting other tables. 
My testing on a local db show this update does in fact work to correctly avoid choosing the buildings which cross the boundary.

Fixes: #  https://toitutewhenua.atlassian.net/browse/TDP-228
