### PR TITLE
docs: update as master theme

### DIFF
--- a/db/docs/source/conf.py
+++ b/db/docs/source/conf.py
@@ -118,6 +118,7 @@ todo_include_todos = False
 # a list of builtin themes.
 # html_theme = 'alabaster'
 # html_theme = "sphinx_rtd_theme"
+html_theme = 'master'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Fixes: #  
change theme to 'master' for readthedocs

### Change Description:

...

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
