### PR TITLE
docs: div docwrapper and max width none

### DIFF
--- a/db/docs/source/_static/custom.css
+++ b/db/docs/source/_static/custom.css
@@ -11,9 +11,13 @@ th {
 .wy-nav-content {
    padding: 1.618em 3.236em;
    height: 100%;
-   max-width: 100%;
+   max-width: none;
    margin: auto;
 
+}
+
+div.bodywrapper {
+   width: 100%;
 }
 
 body {


### PR DESCRIPTION
Fixes: #  
div docwrapper and max width none

### Change Description:

...

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
