### PR TITLE
docs: add default override

### DIFF
--- a/db/docs/source/_static/default.css
+++ b/db/docs/source/_static/default.css
@@ -1,0 +1,25 @@
+tr {
+   background-color: hsla(205, 46%, 86%, 0.41);
+}
+
+th {
+   background-color: #bbbbbb;
+   color: #ffffff;
+}
+
+
+.wy-nav-content {
+   padding: 1.618em 3.236em;
+   height: 100%;
+   max-width: none !important;
+   margin: auto;
+
+}
+
+div.body {
+   width: 100%;
+}
+
+div.section p {
+   font-size: 100%;
+}

--- a/db/docs/source/conf.py
+++ b/db/docs/source/conf.py
@@ -148,6 +148,7 @@ html_logo = "_static/logo2.png"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_css_files = ['_static/default.css',]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -742,7 +743,8 @@ def rstjinja(app, docname, source):
 
 def setup(app):
     app.connect("source-read", rstjinja)
-    app.add_css_file("custom.css")
+    # app.add_css_file("custom.css")
+
 
 
 html_context = context_out


### PR DESCRIPTION
Fixes: #  
over ride css using default.css

### Change Description:

...

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
