### PR TITLE
fix: blank external id field

### DIFF
--- a/buildings/gui/bulk_load_frame.py
+++ b/buildings/gui/bulk_load_frame.py
@@ -215,6 +215,7 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
         self.rad_external_id.setEnabled(1)
         self.rad_external_id.setChecked(False)
         self.fcb_external_id.setDisabled(1)
+        self.fcb_external_id.setLayer(None)
         self.cmb_capture_src_grp.setEnabled(1)
         self.cmb_capture_src_grp.setCurrentIndex(0)
         self.cmb_cap_src_area.setEnabled(1)
@@ -680,4 +681,3 @@ class BulkLoadFrame(QFrame, FORM_CLASS):
         """To ensure QGIS has most up to date ID for the newly split feature see #349"""
         self.cb_added_clicked(False)
         self.cb_added_clicked(True)
- 


### PR DESCRIPTION
Fixes: #  
Bulk loading in QGIS 3.34 fails with error:
`2024-06-20T13:26:46     CRITICAL    Database Error : function buildings_bulk_load.supplied_outlines_insert(integer, numeric, unknown) does not exist
             LINE 1: SELECT buildings_bulk_load.supplied_outlines_insert(81, 3357...
              ^
             HINT: No function matches the given name and argument types. You might need to add explicit type casts.`
             
due to the bulk load frame having the external id field filled with a greyed out "fid"
![image](https://github.com/linz/nz-buildings/assets/25912064/5f0a1d01-3ff8-424f-94f0-d7c336ba576f)
This behavior did not exist in QGIS 3.10.
Forcing the field to be blank on loading the bulk load gui solves this problem.
This change also works with version 3.10.

### Change Description:
Just adding one line to force the gui for external id to be blank on load event.
...

...
