### PR TITLE
feat: coastline and island - update coordinate system to 2193

### DIFF
--- a/buildings/reference_data/topo50.py
+++ b/buildings/reference_data/topo50.py
@@ -230,7 +230,7 @@ def update_coastlines_and_islands(kx_api_key, dataset, dbconn):
     if dataset != "coastlines_and_islands":
         return "error"
     layer = QgsVectorLayer(
-        "https://data.linz.govt.nz/services;key={1}/wfs?service=WFS&version=2.0.0&request=GetFeature&typeNames=layer-{0}&outputFormat=json".format(
+        "https://data.linz.govt.nz/services;key={1}/wfs?service=WFS&version=2.0.0&request=GetFeature&typeNames=layer-{0}&SRSName=EPSG:2193&outputFormat=json".format(
             LDS_LAYER_IDS[dataset], kx_api_key
         )
     )


### PR DESCRIPTION

### Change Description:

Update the plugin so the coastline and island update process will project the data to 2193 

### Notes for Testing:

Run the updates for coastlines and islands in the plugin and check the geometry. (I've run the update today and the geometry is now in the right place)

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
