### PR TITLE
Update buildings from facilities

### DIFF
--- a/buildings/gui/reference_data.py
+++ b/buildings/gui/reference_data.py
@@ -53,6 +53,7 @@ DATASET_LINZ = [
     "coastlines_and_islands",
     "suburb_locality",
     "nz_imagery_survey_index",
+    "nz_facilities"
 ]
 DATASET_STATSNZ = ["territorial_authority"]
 
@@ -71,7 +72,7 @@ DATASET_TOPO50 = [
 ]
 DATASET_ADMIN_BDYS = ["suburb_locality", "territorial_authority"]
 
-DATASET_OTHER = ["nz_imagery_survey_index"]
+DATASET_OTHER = ["nz_imagery_survey_index", "nz_facilities"]
 
 
 class UpdateReferenceData(QFrame, FORM_CLASS):
@@ -135,6 +136,7 @@ class UpdateReferenceData(QFrame, FORM_CLASS):
         self.chbx_suburbs.setEnabled(1)
         self.chbx_ta.setEnabled(1)
         self.chbx_imagery.setEnabled(1)
+        self.chbx_facilities.setEnabled(1)
         self.btn_update.setEnabled(1)
         # clear message
         self.lb_message.setText("")
@@ -158,6 +160,7 @@ class UpdateReferenceData(QFrame, FORM_CLASS):
         self.chbx_suburbs.setDisabled(1)
         self.chbx_ta.setDisabled(1)
         self.chbx_imagery.setDisabled(1)
+        self.chbx_facilities.setDisabled(1)
         self.btn_update.setDisabled(1)
         # add message
         self.lb_message.setText(
@@ -182,7 +185,7 @@ class UpdateReferenceData(QFrame, FORM_CLASS):
             elif dataset in DATASET_ADMIN_BDYS:
                 status = admin_bdys.check_status_admin_bdys(api_key, dataset)
             else:
-                status = other_reference.check_status_imagery_survey_index(
+                status = other_reference.check_status_other_reference(
                     api_key, dataset
                 )
 
@@ -257,6 +260,9 @@ class UpdateReferenceData(QFrame, FORM_CLASS):
         # nz imagery survey index
         if self.chbx_imagery.isChecked():
             self.other_layer_processing("nz_imagery_survey_index")
+        # nz facilities
+        if self.chbx_facilities.isChecked():
+            self.other_layer_processing("nz_facilities")
 
         # create log for this update
         if len(self.updates) > 0:
@@ -384,6 +390,13 @@ class UpdateReferenceData(QFrame, FORM_CLASS):
             return
         if dataset == "nz_imagery_survey_index":
             status = other_reference.update_imagery_survey_index(
+                api_key, dataset, self.db
+            )
+            self.update_message(status, dataset)
+            if status == "updated":
+                self.updates.append(dataset)
+        if dataset == "nz_facilities":
+            status = other_reference.update_facilities(
                 api_key, dataset, self.db
             )
             self.update_message(status, dataset)

--- a/buildings/gui/reference_data.py
+++ b/buildings/gui/reference_data.py
@@ -399,8 +399,8 @@ class UpdateReferenceData(QFrame, FORM_CLASS):
             status = other_reference.update_facilities(
                 api_key, dataset, self.db
             )
-            self.update_message(status, dataset)
-            if status == "updated":
+            self.update_message(status[0], f"{dataset} (Deleted:{status[1]} , Added:{status[2]} , Updated:{status[3]})")
+            if status[0] == "updated":
                 self.updates.append(dataset)
 
     def check_api_key(self, layer):

--- a/buildings/gui/reference_data.ui
+++ b/buildings/gui/reference_data.ui
@@ -246,6 +246,13 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QCheckBox" name="chbx_facilities">
+              <property name="text">
+               <string>NZ Facilities</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/buildings/reference_data/other_reference.py
+++ b/buildings/reference_data/other_reference.py
@@ -217,11 +217,16 @@ def update_facilities(kx_api_key, dataset, dbconn):
 
     if layer.featureCount() == 0:
         return "current"
+    
+    deletes = 0
+    inserts = 0
+    updates = 0
 
     for feature in layer.getFeatures():
         if feature.attribute("__change__") == "DELETE":
             sql = "DELETE FROM buildings_reference.nz_facilities WHERE facility_id = %s;"
             dbconn.execute_no_commit(sql, (feature[external_id],))
+            deletes += 1
 
         elif feature.attribute("__change__") == "INSERT":
             sql = "SELECT True FROM buildings_reference.nz_facilities WHERE facility_id = %s;"
@@ -260,6 +265,7 @@ def update_facilities(kx_api_key, dataset, dbconn):
                         feature.geometry().asWkt(),
                     ),
                 )
+            inserts += 1
 
         elif feature.attribute("__change__") == "UPDATE":
             sql = """  
@@ -291,7 +297,8 @@ def update_facilities(kx_api_key, dataset, dbconn):
                     feature[external_id],
                 ),
             )
-    return "updated"
+            updates += 1
+    return ["updated", deletes, inserts, updates]
 
 
 def correct_attribute_format(value):

--- a/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
+++ b/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
@@ -300,6 +300,10 @@ $$
             u_value,
             bo.shape
     -- Filter buildings to those that don't intersect, or are less than half within, facility polygons
+    -- Uses:
+    --   - SUM of area of intersection: to exclude buildings that are mostly within multiple facility polygons
+    --       (eg. exclude where combined ratio > 0.5, even if it has a ratio < 0.5 to one of the facility polygons)
+    --   - COALESCE 0: to include buildings that don't intersect facilities, by assigning a ratio of 0.
     HAVING 
         COALESCE(SUM(ST_Area(ST_Intersection(bo.shape, f.shape))) / NULLIF(ST_Area(bo.shape), 0), 0) < 0.5
     ),

--- a/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
+++ b/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
@@ -1,0 +1,146 @@
+-- Deploy nz-buildings:buildings/functions/add_update_facilities_attributes_functions to pg
+
+BEGIN;
+
+------------------------------------------------------------------------------
+-- Update Facilities (hospitals and schools) attributes on Building Outlines
+--
+-- Assumes:       - NZ Facilities is current on the LINZ Data Service (LDS).
+-- Prerequisites: - NZ Facilities buildings reference data has been updated
+--                  to match the LDS layer, using the Buildings QGIS Plugin.
+--                - Check NZ Facilities USE values match those in the buildings.use 
+--                  table, using <process>. This is required because NZ Buildings
+--                  have coded values for USE. If there are errors, then NZ Facilities
+--                  might need to be corrected first.
+--
+------------------------------------------------------------------------------
+
+-- TODO - Add separate check before this step to check all facility USEs are
+--        matching buildings.use values corresponding to USE_IDs.
+--      - Add missing building names and uses.
+--      - Retire building names and uses outside of facility polygons. Beware of Supermarkets.
+--      - Add comments
+
+
+-- BUILDING NAME MODIFY
+CREATE OR REPLACE FUNCTION buildings.update_facilities_name_modify()
+RETURNS integer AS
+$$
+    WITH bo_intersects_fac AS (
+        SELECT 
+            building_id AS bo_building_id,
+            building_name_id,
+            building_name,
+            bn_end_lifespan,
+            fac.name AS fac_name,
+            ST_Area(ST_Intersection(bo.shape, fac.shape)) / NULLIF(ST_Area(bo.shape), 0) AS bo_intersect_ratio
+        FROM buildings_reference.nz_facilities fac
+        JOIN (
+            SELECT DISTINCT
+                bo.building_id,
+                bn.building_name_id,
+                bn.building_name,
+                bn.end_lifespan AS bn_end_lifespan,
+                bo.shape
+            FROM buildings.building_outlines bo
+            JOIN buildings.building_name bn USING (building_id)
+			WHERE bo.end_lifespan is NULL
+        ) bo ON ST_Intersects(bo.shape, fac.shape)
+    ),
+    bo_in_fac AS (
+        SELECT *
+        FROM bo_intersects_fac
+        WHERE bo_intersect_ratio > 0.5
+            AND building_name != fac_name
+            AND bn_end_lifespan IS NULL
+    ),
+    updated AS (
+        UPDATE buildings.building_name b_name
+        SET end_lifespan = NOW()
+        FROM bo_in_fac
+        WHERE b_name.building_id = bo_in_fac.bo_building_id
+    ),
+    inserted AS (
+		INSERT INTO buildings.building_name (building_name_id, building_id, building_name, begin_lifespan)
+	    SELECT nextval('buildings.building_name_building_name_id_seq'),
+	        bo_in_fac.bo_building_id,
+	        bo_in_fac.fac_name,
+	        NOW()
+	    FROM bo_in_fac
+	)
+    SELECT count(*)::integer FROM bo_in_fac;
+$$
+LANGUAGE sql VOLATILE;
+
+
+-- BUILDING USE MODIFY
+CREATE OR REPLACE FUNCTION buildings.update_facilities_use_modify()
+RETURNS integer AS
+$$
+    WITH bo_intersects_fac AS (
+        SELECT 
+            building_id AS bo_building_id,
+            building_use_id,
+            use_value,
+            bu_end_lifespan,
+            fac.use AS fac_use,
+            ST_Area(ST_Intersection(bo.shape, fac.shape)) / NULLIF(ST_Area(bo.shape), 0) AS bo_intersect_ratio
+        FROM buildings_reference.nz_facilities fac
+        JOIN (
+            SELECT DISTINCT
+                bo.building_id,
+                bu.building_use_id,
+                u.value AS use_value,
+                bu.end_lifespan AS bu_end_lifespan,
+                bo.shape
+            FROM buildings.building_outlines bo
+            JOIN buildings.building_use bu USING (building_id)
+			JOIN buildings.use u USING (use_id)
+			WHERE bo.end_lifespan is NULL
+        ) bo ON ST_Intersects(bo.shape, fac.shape)
+    ),
+    bo_in_fac AS (
+        SELECT *
+        FROM bo_intersects_fac
+        WHERE bo_intersect_ratio > 0.5
+            AND use_value != fac_use
+            AND bu_end_lifespan IS NULL
+    ),
+    updated AS (
+        UPDATE buildings.building_use b_use
+        SET end_lifespan = NOW()
+        FROM bo_in_fac
+        WHERE b_use.building_id = bo_in_fac.bo_building_id
+    ),
+    inserted AS (
+		INSERT INTO buildings.building_use (building_use_id, building_id, use_id, begin_lifespan)
+	    SELECT nextval('buildings.building_use_building_use_id_seq'),
+	        bo_in_fac.bo_building_id,
+			(SELECT use_id FROM buildings.use WHERE use.value = bo_in_fac.fac_use),
+	        NOW()
+	    FROM bo_in_fac
+	)
+    SELECT count(*)::integer FROM bo_in_fac;
+$$
+LANGUAGE sql VOLATILE;
+
+
+-- UPDATE FACILITIES ATTRIBUTES
+CREATE OR REPLACE FUNCTION buildings.update_facilities_attributes()
+RETURNS TABLE(update_type text, count integer) AS
+$$
+BEGIN
+
+	RETURN QUERY
+    SELECT 'Building NAME modified'::text AS update_type,
+	buildings.update_facilities_name_modify()::integer AS count;
+
+	RETURN QUERY
+    SELECT 'Building USE modified'::text AS update_type,
+	buildings.update_facilities_use_modify()::integer AS count;
+	
+END;
+$$
+LANGUAGE plpgsql VOLATILE;
+
+COMMIT;

--- a/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
+++ b/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
@@ -5,19 +5,19 @@ BEGIN;
 ------------------------------------------------------------------------------
 -- Update Facilities (hospitals and schools) attributes on Building Outlines
 --
--- Assumes:       - NZ Facilities is current on the LINZ Data Service (LDS).
 -- Prerequisites: - NZ Facilities buildings reference data has been updated
 --                  to match the LDS layer, using the Buildings QGIS Plugin.
---                - Check NZ Facilities USE values match those in the buildings.use 
---                  table, using <process>. This is required because NZ Buildings
---                  have coded values for USE. If there are errors, then NZ Facilities
---                  might need to be corrected first.
+--                - Check NZ Facilities attribute errors, using:
+--                      SELECT * FROM buildings_reference.facility_attribute_errors()
+--                  This will find features with USE values that do not match those
+--                  in buildings.use, and also features with null USE or NAME.
+--                  Any errors detected will need to be manually corrected in
+--                  NZ Facilities, prior to updating NZ Buildings attributes
+--                  using this function.
 --
+-- This function can be run by using:
+--     SELECT * FROM buildings.update_facilities_attributes()
 ------------------------------------------------------------------------------
-
--- TODO - Add separate check before this step to check all facility USEs are
---        matching buildings.use values corresponding to USE_IDs.
-
 
 ------------------------------------------------------------------------------
 -- BUILDING NAME MODIFY

--- a/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
+++ b/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
@@ -17,13 +17,16 @@ BEGIN;
 
 -- TODO - Add separate check before this step to check all facility USEs are
 --        matching buildings.use values corresponding to USE_IDs.
---      - Add comments
 
 
+------------------------------------------------------------------------------
 -- BUILDING NAME MODIFY
+-- Where building NAME does not match facility polygon NAME, modify building NAME.
+------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION buildings.update_facilities_name_modify()
 RETURNS integer AS
 $$
+    -- Select buildings and names intersecting facility polygons, excluding retired buildings
     WITH bo_intersects_fac AS (
         SELECT 
             building_id AS bo_building_id,
@@ -45,6 +48,10 @@ $$
 			WHERE bo.end_lifespan is NULL
         ) bo ON ST_Intersects(bo.shape, fac.shape)
     ),
+    -- Filter buildings:
+    --   - More than half the geometry within facility polygon
+    --   - Has a different name to facility name
+    --   - Has a current name
     bo_in_fac AS (
         SELECT *
         FROM bo_intersects_fac
@@ -52,12 +59,14 @@ $$
             AND building_name != fac_name
             AND bn_end_lifespan IS NULL
     ),
+    -- Retire old building name
     updated AS (
         UPDATE buildings.building_name b_name
         SET end_lifespan = NOW()
         FROM bo_in_fac
         WHERE b_name.building_id = bo_in_fac.bo_building_id
     ),
+    -- Add new building name 
     inserted AS (
 		INSERT INTO buildings.building_name (building_name_id, building_id, building_name, begin_lifespan)
 	    SELECT nextval('buildings.building_name_building_name_id_seq'),
@@ -66,15 +75,20 @@ $$
 	        NOW()
 	    FROM bo_in_fac
 	)
+    -- Return count for reporting 
     SELECT count(*)::integer FROM bo_in_fac;
 $$
 LANGUAGE sql VOLATILE;
 
 
+------------------------------------------------------------------------------
 -- BUILDING USE MODIFY
+-- Where building USE does not match facility polygon USE, modify building USE.
+------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION buildings.update_facilities_use_modify()
 RETURNS integer AS
 $$
+    -- Select buildings and uses intersecting facility polygons, excluding retired buildings
     WITH bo_intersects_fac AS (
         SELECT 
             building_id AS bo_building_id,
@@ -97,6 +111,10 @@ $$
 			WHERE bo.end_lifespan is NULL
         ) bo ON ST_Intersects(bo.shape, fac.shape)
     ),
+    -- Filter buildings:
+    --   - More than half the geometry within facility polygon
+    --   - Has a different use to facility use
+    --   - Has a current use
     bo_in_fac AS (
         SELECT *
         FROM bo_intersects_fac
@@ -104,12 +122,14 @@ $$
             AND use_value != fac_use
             AND bu_end_lifespan IS NULL
     ),
+    -- Retire old building use
     updated AS (
         UPDATE buildings.building_use b_use
         SET end_lifespan = NOW()
         FROM bo_in_fac
         WHERE b_use.building_id = bo_in_fac.bo_building_id
     ),
+    -- Add new building use 
     inserted AS (
 		INSERT INTO buildings.building_use (building_use_id, building_id, use_id, begin_lifespan)
 	    SELECT nextval('buildings.building_use_building_use_id_seq'),
@@ -118,15 +138,20 @@ $$
 	        NOW()
 	    FROM bo_in_fac
 	)
+    -- Return count for reporting
     SELECT count(*)::integer FROM bo_in_fac;
 $$
 LANGUAGE sql VOLATILE;
 
 
+------------------------------------------------------------------------------
 -- BUILDING NAME ADD
+-- Where building has no NAME and facility polygon has NAME, add building NAME.
+------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION buildings.update_facilities_name_add()
 RETURNS integer AS
 $$
+    -- Select buildings intersecting facility polygons, excluding retired buildings
     WITH bo_in_fac AS (
         WITH bo_intersects_fac AS (
             SELECT 
@@ -142,10 +167,12 @@ $$
                 WHERE bo.end_lifespan is NULL
             ) bo ON ST_Intersects(bo.shape, fac.shape)
         )
+        -- Filter buildings to those with more than half the geometry within facility polygon
         SELECT *
         FROM bo_intersects_fac
         WHERE bo_intersect_ratio > 0.5
     ),
+    -- Join building name table using LEFT JOIN because building name will be empty
     building_name_joined AS (
     SELECT
         bo_in_fac.fac_name,
@@ -156,6 +183,7 @@ $$
     LEFT JOIN buildings.building_name bn USING (building_id)
     WHERE bn.building_name is NULL
     ),
+    -- Add new building name 
     inserted AS (
         INSERT INTO buildings.building_name (building_name_id, building_id, building_name, begin_lifespan)
         SELECT nextval('buildings.building_name_building_name_id_seq'),
@@ -164,15 +192,20 @@ $$
             NOW()
         FROM building_name_joined
     )
+    -- Return count for reporting 
     SELECT count(*)::integer FROM building_name_joined;
 $$
 LANGUAGE sql VOLATILE;
 
 
+------------------------------------------------------------------------------
 -- BUILDING USE ADD
+-- Where building has no USE and facility polygon has USE, add building USE.
+------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION buildings.update_facilities_use_add()
 RETURNS integer AS
 $$
+    -- Select buildings intersecting facility polygons, excluding retired buildings
     WITH bo_in_fac AS (
         WITH bo_intersects_fac AS (
             SELECT 
@@ -188,10 +221,12 @@ $$
                 WHERE bo.end_lifespan is NULL
             ) bo ON ST_Intersects(bo.shape, fac.shape)
         )
+        -- Filter buildings to those with more than half the geometry within facility polygon
         SELECT *
         FROM bo_intersects_fac
         WHERE bo_intersect_ratio > 0.5
     ),
+    -- Join building use table using LEFT JOIN because building use will be empty
     building_use_joined AS (
     SELECT
         bo_in_fac.fac_use,
@@ -203,6 +238,7 @@ $$
     LEFT JOIN buildings.use u USING (use_id)
     WHERE bu.building_use_id is NULL
     ),
+    -- Add new building use 
     inserted AS (
         INSERT INTO buildings.building_use (building_use_id, building_id, use_id, begin_lifespan)
         SELECT nextval('buildings.building_use_building_use_id_seq'),
@@ -211,15 +247,24 @@ $$
             NOW()
         FROM building_use_joined
     )
+    -- Return count for reporting 
     SELECT count(*)::integer FROM building_use_joined;
 $$
 LANGUAGE sql VOLATILE;
 
 
+------------------------------------------------------------------------------
 -- BUILDING NAME/USE REMOVE
+-- Where building has NAME/USE with no matching facility polygon, remove NAME/USE.
+-- Only remove NAME/USE for USE types included in NZ Facilities, currently
+-- these are Hospitals and Schools.  Other USE types do not have corresponding
+-- facility polygons to compare, so removal of NAME and USE needs to be in the same
+-- function.
+------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION buildings.update_facilities_name_use_remove()
 RETURNS integer AS
 $$
+    -- Select buildings with a use that is included in NZ Facilities, excluding retired uses and retired buildings
     WITH bo_has_use AS (
         SELECT
             building_id,
@@ -232,10 +277,11 @@ $$
         JOIN buildings.building_name bn USING (building_id)
         JOIN buildings.building_use bu USING (building_id)
         JOIN buildings.use u USING (use_id)
-        WHERE u.use_id IN (16,27) -- Hospital = 16, School = 27
+        WHERE u.use_id IN (16,27) -- use_id 16 = Hospital, 27 = School
             AND bu.end_lifespan IS NULL
             AND bo.end_lifespan IS NULL
     ),
+    -- Join facility polygons using intersects and LEFT JOIN because we want to include those with no intersect
     bo_outside_fac AS (
     SELECT 
         building_id,
@@ -253,9 +299,11 @@ $$
             bu_building_use_id,
             u_value,
             bo.shape
+    -- Filter buildings to those that don't intersect, or are less than half within, facility polygons
     HAVING 
         COALESCE(SUM(ST_Area(ST_Intersection(bo.shape, f.shape))) / NULLIF(ST_Area(bo.shape), 0), 0) < 0.5
     ),
+    -- Remove building name
     remove_name AS (
         UPDATE buildings.building_name b_name
         SET end_lifespan = NOW()
@@ -263,6 +311,7 @@ $$
         WHERE b_name.building_id = bo_outside_fac.building_id
             AND b_name.end_lifespan is NULL
     ),
+    -- Remove building use
     remove_use AS (
         UPDATE buildings.building_use b_use
         SET end_lifespan = NOW()
@@ -270,12 +319,17 @@ $$
         WHERE b_use.building_id = bo_outside_fac.building_id
             AND b_use.end_lifespan is NULL
     )
+    -- Return count for reporting 
     SELECT count(*)::integer FROM bo_outside_fac;
 $$
 LANGUAGE sql VOLATILE;
 
 
+------------------------------------------------------------------------------
 -- UPDATE FACILITIES ATTRIBUTES
+-- Wrapper to run all update facilities functions.
+-- Returns a table with each update type and the count of buildings updated.
+------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION buildings.update_facilities_attributes()
 RETURNS TABLE(update_type text, count integer) AS
 $$

--- a/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
+++ b/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql
@@ -26,13 +26,12 @@ BEGIN;
 CREATE OR REPLACE FUNCTION buildings.update_facilities_name_modify()
 RETURNS integer AS
 $$
-    -- Select buildings and names intersecting facility polygons, excluding retired buildings
+    -- Select buildings and names intersecting facility polygons, excluding retired buildings and names
     WITH bo_intersects_fac AS (
         SELECT 
             building_id AS bo_building_id,
             building_name_id,
             building_name,
-            bn_end_lifespan,
             fac.name AS fac_name,
             ST_Area(ST_Intersection(bo.shape, fac.shape)) / NULLIF(ST_Area(bo.shape), 0) AS bo_intersect_ratio
         FROM buildings_reference.nz_facilities fac
@@ -41,23 +40,21 @@ $$
                 bo.building_id,
                 bn.building_name_id,
                 bn.building_name,
-                bn.end_lifespan AS bn_end_lifespan,
                 bo.shape
             FROM buildings.building_outlines bo
             JOIN buildings.building_name bn USING (building_id)
 			WHERE bo.end_lifespan is NULL
+                AND bn.end_lifespan IS NULL
         ) bo ON ST_Intersects(bo.shape, fac.shape)
     ),
     -- Filter buildings:
     --   - More than half the geometry within facility polygon
     --   - Has a different name to facility name
-    --   - Has a current name
     bo_in_fac AS (
         SELECT *
         FROM bo_intersects_fac
         WHERE bo_intersect_ratio > 0.5
             AND building_name != fac_name
-            AND bn_end_lifespan IS NULL
     ),
     -- Retire old building name
     updated AS (
@@ -88,13 +85,12 @@ LANGUAGE sql VOLATILE;
 CREATE OR REPLACE FUNCTION buildings.update_facilities_use_modify()
 RETURNS integer AS
 $$
-    -- Select buildings and uses intersecting facility polygons, excluding retired buildings
+    -- Select buildings and uses intersecting facility polygons, excluding retired buildings and uses
     WITH bo_intersects_fac AS (
         SELECT 
             building_id AS bo_building_id,
             building_use_id,
             use_value,
-            bu_end_lifespan,
             fac.use AS fac_use,
             ST_Area(ST_Intersection(bo.shape, fac.shape)) / NULLIF(ST_Area(bo.shape), 0) AS bo_intersect_ratio
         FROM buildings_reference.nz_facilities fac
@@ -103,24 +99,22 @@ $$
                 bo.building_id,
                 bu.building_use_id,
                 u.value AS use_value,
-                bu.end_lifespan AS bu_end_lifespan,
                 bo.shape
             FROM buildings.building_outlines bo
             JOIN buildings.building_use bu USING (building_id)
 			JOIN buildings.use u USING (use_id)
 			WHERE bo.end_lifespan is NULL
+                AND bu.end_lifespan IS NULL
         ) bo ON ST_Intersects(bo.shape, fac.shape)
     ),
     -- Filter buildings:
     --   - More than half the geometry within facility polygon
     --   - Has a different use to facility use
-    --   - Has a current use
     bo_in_fac AS (
         SELECT *
         FROM bo_intersects_fac
         WHERE bo_intersect_ratio > 0.5
             AND use_value != fac_use
-            AND bu_end_lifespan IS NULL
     ),
     -- Retire old building use
     updated AS (

--- a/db/sql/deploy/buildings_reference/add_nz_facilities.sql
+++ b/db/sql/deploy/buildings_reference/add_nz_facilities.sql
@@ -1,0 +1,24 @@
+-- Deploy nz-buildings:buildings_reference/add_nz_imagery_survey_index to pg
+
+BEGIN;
+
+CREATE TABLE buildings_reference.nz_facilities (
+      facility_id integer NOT NULL
+    , source_facility_id character varying(80)
+    , name character varying(250)
+    , source_name character varying(250)
+    , use character varying(40)
+    , use_type character varying(150)
+    , use_subtype character varying(150)
+    , estimated_occupancy integer
+    , last_modified date
+    , shape public.geometry(MultiPolygon, 2193)
+);
+
+CREATE INDEX sidx_nz_facilities_shape
+    ON buildings_reference.nz_facilities USING gist (shape);
+
+COMMENT ON TABLE buildings_reference.nz_facilities IS
+'A copy of the NZ Facilities table that contains hospitals and schools attributes';
+
+COMMIT;

--- a/db/sql/deploy/buildings_reference/add_nz_facilities.sql
+++ b/db/sql/deploy/buildings_reference/add_nz_facilities.sql
@@ -3,7 +3,7 @@
 BEGIN;
 
 CREATE TABLE buildings_reference.nz_facilities (
-      facility_id integer NOT NULL
+      facility_id integer PRIMARY KEY
     , source_facility_id character varying(80)
     , name character varying(250)
     , source_name character varying(250)

--- a/db/sql/deploy/buildings_reference/add_nz_facilities.sql
+++ b/db/sql/deploy/buildings_reference/add_nz_facilities.sql
@@ -21,4 +21,8 @@ CREATE INDEX sidx_nz_facilities_shape
 COMMENT ON TABLE buildings_reference.nz_facilities IS
 'A copy of the NZ Facilities table that contains hospitals and schools attributes';
 
+-- Add columns to Update Reference Log table
+
+ALTER TABLE buildings_reference.reference_update_log ADD facilities boolean DEFAULT False;
+
 COMMIT;

--- a/db/sql/deploy/buildings_reference/add_nz_facilities.sql
+++ b/db/sql/deploy/buildings_reference/add_nz_facilities.sql
@@ -1,4 +1,4 @@
--- Deploy nz-buildings:buildings_reference/add_nz_imagery_survey_index to pg
+-- Deploy nz-buildings:buildings_reference/add_nz_facilities to pg
 
 BEGIN;
 

--- a/db/sql/deploy/buildings_reference/functions/add_check_facilities_attributes_function.sql
+++ b/db/sql/deploy/buildings_reference/functions/add_check_facilities_attributes_function.sql
@@ -1,4 +1,4 @@
--- Deploy nz-buildings:buildings_reference/functions/add_facilities_attribute_check to pg
+-- Deploy nz-buildings:buildings_reference/functions/add_check_facilities_attributes_function to pg
 
 ------------------------------------------------------------------------------
 -- Checks NZ Facilities (hospitals and schools) attributes are valid in buildings_reference.

--- a/db/sql/deploy/buildings_reference/functions/add_facilities_attribute_check_function.sql
+++ b/db/sql/deploy/buildings_reference/functions/add_facilities_attribute_check_function.sql
@@ -1,0 +1,70 @@
+-- Deploy nz-buildings:buildings_reference/functions/add_facilities_attribute_check to pg
+
+------------------------------------------------------------------------------
+-- Checks NZ Facilities (hospitals and schools) attributes are valid in buildings_reference.
+--
+-- This function should be run and errors corrected, prior to running the
+-- "buildings.update_facilities_attributes" function.
+--
+-- Attribute errors checked:
+--     - Invaild USE (that doesn't match the NZ Buildings coded values for USE)
+--     - Null USE
+--     - Null NAME
+--
+-- This function can be run by using:
+--     SELECT * FROM buildings_reference.facility_attribute_errors()
+------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION buildings_reference.facility_attribute_errors()
+RETURNS TABLE (
+	error_type text,
+	error_count integer,
+	error_attributes text[],
+	facility_ids integer[]
+)
+LANGUAGE sql
+AS $$
+	-- Find features with invalid use
+	WITH invalid_use AS (
+		SELECT *
+		FROM buildings_reference.nz_facilities
+   		WHERE use NOT IN ('Hospital','School')
+		ORDER BY facility_id
+	),
+	-- Find features with null use
+	null_use AS (
+		SELECT *
+		FROM buildings_reference.nz_facilities
+   		WHERE use IS NULL
+		ORDER BY facility_id
+	),
+	-- Find features with null name
+	null_name AS (
+		SELECT *
+		FROM buildings_reference.nz_facilities
+   		WHERE name IS NULL
+		ORDER BY facility_id
+	)
+	-- Report features with invalid use
+    SELECT
+		'Invalid Use' AS error_type,
+		COUNT(*) AS error_count,
+		ARRAY_AGG(use) AS error_attributes,
+		ARRAY_AGG(facility_id) AS facility_ids
+	FROM invalid_use
+	-- Report featues with null use
+	UNION ALL
+	SELECT
+		'Empty Use' AS error_type,
+		COUNT(*) AS error_count,
+		ARRAY_AGG(use) AS error_attributes,
+		ARRAY_AGG(facility_id) AS facility_ids
+	FROM null_use
+	-- Report features with null name
+	UNION ALL
+	SELECT
+		'Empty Name' AS error_type,
+		COUNT(*) AS error_count,
+		ARRAY_AGG(name) AS error_attributes,
+		ARRAY_AGG(facility_id) AS facility_ids
+	FROM null_name;
+$$;

--- a/db/sql/deploy/buildings_reference/functions/reference_update_log.sql
+++ b/db/sql/deploy/buildings_reference/functions/reference_update_log.sql
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION buildings_reference.reference_update_log_insert_log(p
 RETURNS integer AS
 $$
 
-    INSERT INTO buildings_reference.reference_update_log (river, lake, pond, swamp, lagoon, canal, coastlines_and_islands, capture_source_area, territorial_authority, territorial_authority_grid, suburb_locality, hut, shelter, bivouac, protected_areas, imagery_survey_index)
+    INSERT INTO buildings_reference.reference_update_log (river, lake, pond, swamp, lagoon, canal, coastlines_and_islands, capture_source_area, territorial_authority, territorial_authority_grid, suburb_locality, hut, shelter, bivouac, protected_areas, imagery_survey_index, facilities)
     VALUES(CASE WHEN ('river_polygons' = ANY(p_list)) THEN True ELSE False END,
            CASE WHEN ('lake_polygons' = ANY(p_list)) THEN True ELSE False END,
            CASE WHEN ('pond_polygons' = ANY(p_list)) THEN True ELSE False END,
@@ -40,7 +40,8 @@ $$
            CASE WHEN ('shelter_points' = ANY(p_list)) THEN True ELSE False END,
            CASE WHEN ('bivouac_points' = ANY(p_list)) THEN True ELSE False END,
            CASE WHEN ('protected_areas_polygons' = ANY(p_list)) THEN True ELSE False END,
-           CASE WHEN ('nz_imagery_survey_index' = ANY(p_list)) THEN True ELSE False END
+           CASE WHEN ('nz_imagery_survey_index' = ANY(p_list)) THEN True ELSE False END,
+           CASE WHEN ('nz_facilities' = ANY(p_list)) THEN True ELSE False END
     )
     RETURNING update_id;
 


### PR DESCRIPTION
Enhanced to enable building outlines facility attributes (hospital and school name and use) to be updated based on updated facilities layer.

### Change Description:
- Added create new table buildings_reference.nz_facilities
- Added buildings_reference.nz_facilities to the Update Reference Data process in the Buildings Plugin
- Added postgres functions to compare and update buildings to match facility polygons
- Added postgres function to check facility polygons name and use attributes are valid (Mainly because Facilities USE needs to correctly match the coded values in `buildings.use` table)

### Notes for Testing:
1) Use a local test DB of Buildings or maybe test on DEV server.
    - We will be using `buildings` and `buildings_reference` schemas.
    - Ensure `.local/share/QGIS/QGIS3/profiles/default/buildings/config.ini` is pointing to the correct DB
2) In pgAdmin, run `nz-buildings/db/sql/deploy/buildings_reference/add_nz_facilities.sql`
    - Check this creates an empty DB table `buildings_reference.nz_facilities`, and
    - Check this adds a `facilities` column to `buildings_reference.reference_update_log`, and
    - Also run `nz-buildings/db/sql/deploy/buildings_reference/functions/reference_update_log.sql` to enable log updates for facilities.
3) In QGIS, open the Buildings Maintenance plugin.
    - Click on the bottom icon, Update Reference Data
    - Select NZ Facilities
    - Click on Update
    - Check `buildings_reference.nz_facilities` is now updated (the table is now populated with facility polygons)
4) In pgAdmin, run `nz-buildings/db/sql/deploy/buildings_reference/functions/add_check_facilities_attributes_function.sql`
    - run `SELECT * FROM buildings_reference.facility_attribute_errors()`
    - This checks for any invalid attributes.
5) In pgAdmin, run `nz-buildings/db/sql/deploy/buildings/functions/add_update_facilities_attributes_function.sql`
    - run `SELECT * FROM buildings.update_facilities_attributes()`
    - This takes about 1 minute to run locally.
    - This compares buildings to facility polygons and updates buildings where required.
6) To test specific scenarios, you can make test edits to `buildings_reference.nz_facilities` and re-run the previous step or two.


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
